### PR TITLE
Fix #28

### DIFF
--- a/json/alias.json
+++ b/json/alias.json
@@ -1,5 +1,5 @@
 {
-  "$id": "alias.json",
+  "$id": "json/alias.json",
   "type": "object",
   "additionalProperties": false,
   "anyOf": [

--- a/json/character.json
+++ b/json/character.json
@@ -1,5 +1,5 @@
 {
-  "$id": "character.json",
+  "$id": "json/character.json",
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/json/image.json
+++ b/json/image.json
@@ -1,5 +1,5 @@
 {
-  "$id": "image.json",
+  "$id": "json/image.json",
   "type": "object",
   "additionalProperties": false,
   "required": ["featured"],

--- a/json/media.json
+++ b/json/media.json
@@ -1,5 +1,5 @@
 {
-  "$id": "media.json",
+  "$id": "json/media.json",
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/schema.builtin.json
+++ b/schema.builtin.json
@@ -1,7 +1,8 @@
 {
-  "$id": "builtin.json",
+  "$id": "schema.builtin.json",
+  "$schema": "http://json-schema.org/schema",
   "$comment": "Only used for the builtin packs. Those properties don't work on normal manual packs.",
-  "allOf": [{ "$ref": "index.json" }],
+  "allOf": [{ "$ref": "schema.json" }],
   "required": ["type", "author"],
   "properties": {
     "type": {

--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,6 @@
 {
-  "$id": "index.json",
+  "$id": "schema.json",
+  "$schema": "http://json-schema.org/schema",
   "type": "object",
   "required": ["id"],
   "properties": {
@@ -63,7 +64,7 @@
           "type": "array",
           "description": "A list of new media to add",
           "items": {
-            "allOf": [{ "$ref": "media.json" }],
+            "allOf": [{ "$ref": "json/media.json" }],
             "required": ["id", "title", "type", "format"]
           }
         },
@@ -87,7 +88,7 @@
           "type": "array",
           "description": "A list of new characters to add",
           "items": {
-            "allOf": [{ "$ref": "character.json" }],
+            "allOf": [{ "$ref": "json/character.json" }],
             "required": ["id", "name"]
           }
         },

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -179,22 +179,27 @@ const handler = async (r: Request) => {
   return new discord.Message().setContent(`Unimplemented!`).send();
 };
 
+function cache(age: number): (req: Request, res: Response) => Response {
+  return (_: Request, response: Response): Response => {
+    response.headers.set('Cache-Control', `public, max-age=${age}`);
+    return response;
+  };
+}
+
 serve({
   '/': handler,
   '/dev': handler,
   '/external/*': utils.proxy,
-  '/schema': serveStatic('../json/index.json', {
+  '/schema': serveStatic('../schema.json', {
     baseUrl: import.meta.url,
-    intervene: (_, response) => {
-      response.headers.set('Cache-Control', 'public, max-age=86400');
-      return response;
-    },
+    intervene: cache(86400),
+  }),
+  '/json/:filename+': serveStatic('../json', {
+    baseUrl: import.meta.url,
+    intervene: cache(86400),
   }),
   '/file/:filename+': serveStatic('../assets/public', {
     baseUrl: import.meta.url,
-    intervene: (_, response) => {
-      response.headers.set('Cache-Control', 'public, max-age=604800');
-      return response;
-    },
+    intervene: cache(604800),
   }),
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -203,6 +203,8 @@ const proxy = async (r: Request) => {
   try {
     const encoded = new URL(r.url);
 
+    // const searchParams = encoded.searchParams;
+
     const url = new URL(
       decodeURIComponent(encoded.pathname.substring('/external/'.length)),
     );
@@ -210,16 +212,13 @@ const proxy = async (r: Request) => {
     const image = url ? await fetch(url) : undefined;
     const type = image?.headers.get('content-type');
 
-    // NOTE discord doesn't allow any gif that doesn't end with the file extension
-    // I suspect it's some kind of nitro restriction thingy like the one with APNGs
-    // but for now so it's clear that the gif is invalid we straight out refuse it
+    // FIXME discord doesn't allow any gif that doesn't end with the file extension
+    // (see #39)
     if (type === 'image/gif' && !url.pathname.endsWith('.gif')) {
       throw new Error();
     }
 
-    // const searchParams = encoded.searchParams;
-
-    // TODO IMPORTANT apply size parameter
+    // TODO IMPORTANT apply ?size= parameter
 
     // TODO image customization
     //(see https://github.com/ker0olos/fable/issues/24)

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -20,11 +20,11 @@ import character from '../json/character.json' assert {
   type: 'json',
 };
 
-import index from '../json/index.json' assert {
+import index from '../schema.json' assert {
   type: 'json',
 };
 
-import builtin from '../json/builtin.json' assert {
+import builtin from '../schema.builtin.json' assert {
   type: 'json',
 };
 
@@ -127,7 +127,7 @@ export const prettify = (
       .replace(new RegExp(`"ERROR/${index}",`), `${message}\n${underline}`)
       .replace(
         new RegExp(`(.*)ERROR/${index}"`),
-        (_, s) => `${s}" >>> ${message}\n${underline}`,
+        (_: unknown, s: string) => `${s}" >>> ${message}\n${underline}`,
       );
   });
 


### PR DESCRIPTION
The rest of the json schemas weren't being served. We were only serving "index.json". This meant any validator trying to validate against "https://fable.deno.dev/schema" would error out.