### PR TITLE
Search Improvements

### DIFF
--- a/packs/anilist/api.ts
+++ b/packs/anilist/api.ts
@@ -167,7 +167,7 @@ export async function media(
   const query = gql`
     query ($ids: [Int], $search: String) {
       Page {
-        media(search: $search, id_in: $ids, sort: ${mediaDefaultSort}) {
+        media(search: $search, id_in: $ids, sort: ${mediaDefaultSort}, isAdult: false) {
           ${mediaDefaultQuery}
           relations {
             edges {
@@ -233,7 +233,7 @@ export async function nextEpisode(
 ): Promise<AniListMedia> {
   const query = gql`
     query ($search: String) {
-      Media(search: $search, type: ANIME, sort: ${mediaDefaultSort}) {
+      Media(search: $search, type: ANIME, sort: ${mediaDefaultSort}, isAdult: false) {
         title {
           english
           romaji
@@ -270,8 +270,8 @@ export async function pool(
           sort: ${mediaDefaultSort},
           popularity_greater: $popularity_greater,
           popularity_lesser: $popularity_lesser,
-          format_not_in: [ NOVEL, MUSIC, SPECIAL ], # fixed to query characters that only appear in anime, movies, and manga
-          isAdult: false, # ignore hentai (not 100% reliable according to anilist)
+          format_not_in: [ NOVEL, MUSIC, SPECIAL ],
+          isAdult: false
         ) {
           # TODO BLOCKED only requests the first page
           characters(role: $role, sort: ${characterDefaultSort}, perPage: 25) {

--- a/packs/vtubers/manifest.json
+++ b/packs/vtubers/manifest.json
@@ -5,7 +5,12 @@
   "description": "A pack containing a set of the most famous vtubers",
   "type": "builtin",
   "media": {
-    "conflicts": ["anilist:145478", "anilist:118123", "anilist:139756"],
+    "conflicts": [
+      "anilist:145478",
+      "anilist:118123",
+      "anilist:139756",
+      "anilist:129963"
+    ],
     "new": [{
       "id": "hololive",
       "type": "ANIME",

--- a/packs/vtubers/manifest.json
+++ b/packs/vtubers/manifest.json
@@ -5,7 +5,7 @@
   "description": "A pack containing a set of the most famous vtubers",
   "type": "builtin",
   "media": {
-    "conflicts": ["anilist:145478", "anilist:118123"],
+    "conflicts": ["anilist:145478", "anilist:118123", "anilist:139756"],
     "new": [{
       "id": "hololive",
       "type": "ANIME",

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -99,7 +99,6 @@ const handler = async (r: Request) => {
             const results = await packs.searchMany<Media>(
               'media',
               query,
-              50,
             );
 
             results?.forEach((media) => {
@@ -121,7 +120,6 @@ const handler = async (r: Request) => {
             const results = await packs.searchMany<Character>(
               'characters',
               query,
-              50,
             );
 
             results?.forEach((character) => {

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -24,6 +24,8 @@ import { ManifestType } from './types.ts';
 
 await initConfig();
 
+const sep = 'id=';
+
 const handler = async (r: Request) => {
   const { origin } = new URL(r.url);
 
@@ -83,22 +85,37 @@ const handler = async (r: Request) => {
         switch (name) {
           case 'search':
           case 'anime':
-          case 'manga':
+          case 'manga': {
+            const query = options['query'] as string;
             return (await search.media({
               debug: Boolean(options['debug']),
-              search: options['query'] as string,
+              id: query.startsWith(sep)
+                ? query.substring(sep.length)
+                : undefined,
+              search: query,
             })).send();
-          case 'character':
+          }
+          case 'character': {
+            const query = options['query'] as string;
             return (await search.character({
               debug: Boolean(options['debug']),
-              search: options['query'] as string,
+              id: query.startsWith(sep)
+                ? query.substring(sep.length)
+                : undefined,
+              search: query,
             })).send();
+          }
           case 'music':
           case 'songs':
-          case 'themes':
+          case 'themes': {
+            const query = options['query'] as string;
             return (await search.music({
-              search: options['query'] as string,
+              id: query.startsWith(sep)
+                ? query.substring(sep.length)
+                : undefined,
+              search: query,
             })).send();
+          }
           case 'w':
           case 'roll':
           case 'pull':

--- a/src/search.ts
+++ b/src/search.ts
@@ -161,9 +161,6 @@ function mediaEmbed(media: Media, titles: string[]): discord.Embed {
     .setImage({
       default: true,
       url: media.images?.[0].url,
-    })
-    .setFooter({
-      text: titles[0] !== media.title.native ? media.title.native : undefined,
     });
 }
 

--- a/src/search.ts
+++ b/src/search.ts
@@ -26,9 +26,8 @@ export async function media(
     debug?: boolean;
   },
 ): Promise<discord.Message> {
-  const results: (Media | DisaggregatedMedia)[] = await packs.media(
-    id ? { ids: [id] } : { search },
-  );
+  const results: (Media | DisaggregatedMedia)[] = await packs
+    .media(id ? { ids: [id] } : { search });
 
   if (!results.length) {
     throw new Error('404');
@@ -207,9 +206,7 @@ export async function character(
   },
 ): Promise<discord.Message> {
   const results: (Character | DisaggregatedCharacter)[] = await packs
-    .characters(
-      id ? { ids: [id] } : { search },
-    );
+    .characters(id ? { ids: [id] } : { search });
 
   if (!results.length) {
     throw new Error('404');
@@ -369,11 +366,13 @@ function characterDebugEmbed(character: Character): discord.Embed {
 }
 
 export async function music(
-  { search }: {
+  { id, search }: {
+    id?: string;
     search?: string;
   },
 ): Promise<discord.Message> {
-  const results = await packs.media({ search });
+  const results: (Media | DisaggregatedMedia)[] = await packs
+    .media(id ? { ids: [id] } : { search });
 
   if (!results.length) {
     throw new Error('404');

--- a/tests/discord.test.ts
+++ b/tests/discord.test.ts
@@ -252,6 +252,38 @@ Deno.test('components', async (test) => {
   });
 });
 
+Deno.test('suggestions', async (test) => {
+  await test.step('normal', () => {
+    const message = new discord.Message();
+
+    message.addSuggestions({ name: 'a', value: 'b' }, { value: 'c' });
+
+    assertEquals(message.json(), {
+      type: 8,
+      data: {
+        choices: [{
+          name: 'a',
+          value: 'b',
+        }, {
+          name: 'c',
+          value: 'c',
+        }],
+      },
+    });
+  });
+
+  await test.step('no suggestions', () => {
+    const message = new discord.Message(discord.MessageType.Suggestions);
+
+    assertEquals(message.json(), {
+      type: 8,
+      data: {
+        choices: [],
+      },
+    });
+  });
+});
+
 Deno.test('messages', async (test) => {
   const message = new discord.Message();
 
@@ -300,7 +332,7 @@ Deno.test('messages', async (test) => {
 
     assertEquals(message.json().type, 7);
 
-    message.setType(discord.MessageType.Ping);
+    message.setType(discord.MessageType.Pong);
 
     assertEquals(message.json().type, 1);
   });

--- a/tests/gacha.test.ts
+++ b/tests/gacha.test.ts
@@ -503,10 +503,10 @@ Deno.test('disabled', async (test) => {
       await assertRejects(
         () => gacha.rngPull(),
         Error,
-        'failed to pull a character due to the pool not containing any characters that match the randomly chosen variables',
+        'failed to create a pool with {"popularity_greater":0,"popularity_lesser":100,"pages":[null],"current_pool":0,"minimal_pool":25}',
       );
 
-      assertSpyCalls(fetchStub, 1);
+      assertSpyCalls(fetchStub, 3);
       assertSpyCalls(rngStub, 1);
     } finally {
       rngStub.restore();

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -89,9 +89,6 @@ Deno.test('media', async (test) => {
             author: {
               name: 'Anime',
             },
-            footer: {
-              text: 'native title',
-            },
             title: 'english title',
             color: 16777215,
             description: 'long description',
@@ -1739,7 +1736,7 @@ Deno.test('character', async (test) => {
           Promise.resolve({
             data: {
               Page: {
-                characters: [character],
+                characters: [],
               },
             },
           })),
@@ -2385,7 +2382,7 @@ Deno.test('character debug', async (test) => {
           Promise.resolve({
             data: {
               Page: {
-                characters: [character],
+                characters: [],
               },
             },
           })),

--- a/tests/packs.test.ts
+++ b/tests/packs.test.ts
@@ -15,6 +15,8 @@ import { assertValidManifest } from '../src/validate.ts';
 
 import packs from '../src/packs.ts';
 
+import * as anilist from '../packs/anilist/api.ts';
+
 import {
   Character,
   CharacterRole,
@@ -198,7 +200,147 @@ Deno.test('disabled embeds', async (test) => {
 });
 
 Deno.test('disabled relations', async (test) => {
-  await test.step('disabled media relations', async () => {
+  await test.step('disabled anilist media relations', () => {
+    const media: AniListMedia = {
+      id: '1',
+      type: MediaType.Anime,
+      format: MediaFormat.TV,
+      title: {
+        english: 'title',
+      },
+      relations: {
+        edges: [{
+          relationType: MediaRelation.Contains,
+          node: {
+            id: '2',
+            type: MediaType.Anime,
+            format: MediaFormat.TV,
+            title: {
+              english: 'title 2',
+            },
+          },
+        }],
+      },
+    };
+
+    const manifest: Manifest = {
+      id: 'pack-id',
+      media: {
+        conflicts: ['anilist:2'],
+      },
+    };
+
+    const listStub = stub(
+      packs,
+      'list',
+      () => [manifest],
+    );
+
+    try {
+      assertEquals(
+        anilist.transform<Media>({ item: media })
+          .relations?.edges.length,
+        0,
+      );
+    } finally {
+      listStub.restore();
+      packs.clear();
+    }
+  });
+
+  await test.step('disabled anilist media characters', () => {
+    const media: AniListMedia = {
+      id: '1',
+      type: MediaType.Anime,
+      format: MediaFormat.TV,
+      title: {
+        english: 'title',
+      },
+      characters: {
+        edges: [{
+          role: CharacterRole.Main,
+          node: {
+            id: '2',
+            name: {
+              full: 'name',
+            },
+          },
+        }],
+      },
+    };
+
+    const manifest: Manifest = {
+      id: 'pack-id',
+      media: {
+        conflicts: ['anilist:2'],
+      },
+    };
+
+    const listStub = stub(
+      packs,
+      'list',
+      () => [manifest],
+    );
+
+    try {
+      assertEquals(
+        anilist.transform<Media>({ item: media })
+          .characters?.edges.length,
+        0,
+      );
+    } finally {
+      listStub.restore();
+      packs.clear();
+    }
+  });
+
+  await test.step('disabled anilist character media', () => {
+    const character: AniListCharacter = {
+      id: '1',
+      name: {
+        full: 'name',
+      },
+      media: {
+        edges: [{
+          characterRole: CharacterRole.Main,
+          node: {
+            id: '2',
+            type: MediaType.Anime,
+            format: MediaFormat.TV,
+            title: {
+              english: 'title',
+            },
+          },
+        }],
+      },
+    };
+
+    const manifest: Manifest = {
+      id: 'pack-id',
+      media: {
+        conflicts: ['anilist:2'],
+      },
+    };
+
+    const listStub = stub(
+      packs,
+      'list',
+      () => [manifest],
+    );
+
+    try {
+      assertEquals(
+        anilist.transform<Character>({ item: character })
+          .media?.edges.length,
+        0,
+      );
+    } finally {
+      listStub.restore();
+      packs.clear();
+    }
+  });
+
+  await test.step('disabled packs media relations', async () => {
     const manifest: Manifest = {
       id: 'pack-id',
       media: {
@@ -256,7 +398,7 @@ Deno.test('disabled relations', async (test) => {
     }
   });
 
-  await test.step('disabled media characters', async () => {
+  await test.step('disabled packs media characters', async () => {
     const manifest: Manifest = {
       id: 'pack-id',
       media: {
@@ -311,7 +453,7 @@ Deno.test('disabled relations', async (test) => {
     }
   });
 
-  await test.step('disabled character media', async () => {
+  await test.step('disabled packs character media', async () => {
     const manifest: Manifest = {
       id: 'pack-id',
       characters: {

--- a/update_commands.ts
+++ b/update_commands.ts
@@ -137,6 +137,10 @@ async function put(commands: CommandsArray): Promise<void> {
     console.log('Updating guild commands for dev bot\n\n');
   }
 
+  if (commands.length > 100) {
+    throw new Error('the maximum number of commands allowed is 100');
+  }
+
   const url = GUILD_ID
     ? `https://discord.com/api/v10/applications/${APP_ID}/guilds/${GUILD_ID}/commands`
     : `https://discord.com/api/v10/applications/${APP_ID}/commands`;
@@ -162,12 +166,13 @@ put([
   // uses characters and media from all packs
   ...Command({
     name: 'search',
-    aliases: ['anime', 'manga'],
+    aliases: ['anime', 'manga', 'media'],
     description: 'Search for an anime/manga',
     options: [
       Option({
         name: 'query',
         description: 'The title for an anime/manga',
+        autocomplete: true,
         type: Type.STRING,
       }),
       Option({
@@ -185,6 +190,7 @@ put([
       Option({
         name: 'query',
         description: 'The title of the character',
+        autocomplete: true,
         type: Type.STRING,
       }),
       Option({
@@ -203,6 +209,7 @@ put([
       Option({
         name: 'query',
         description: 'The title for an anime/manga',
+        autocomplete: true,
         type: Type.STRING,
       }),
     ],

--- a/update_commands.ts
+++ b/update_commands.ts
@@ -43,15 +43,17 @@ enum Permission {
 }
 
 const Option = (
-  { name, description, type, optional }: {
+  { name, description, type, autocomplete, optional }: {
+    type: Type;
     name: string;
     description: string;
-    type: Type;
+    autocomplete?: boolean;
     optional?: boolean;
   },
 ) => ({
   name,
   description,
+  autocomplete,
   type: type.valueOf(),
   required: !optional,
 });


### PR DESCRIPTION
- allow searching by id
_prefixing queries with `id=` triggers an id search instead of normal substring searches_

- search suggestions and auto-completion 
_when searching for characters and media, you will see suggestions as you type_

![image](https://user-images.githubusercontent.com/52022280/214962807-dc695d6e-0a75-4d57-8700-488e6eaae929.png)
