### PR TITLE
Hotfix 3

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -719,6 +719,7 @@ export class Message {
             target ?? '',
             // deno-lint-ignore no-non-null-assertion
             `${index - 1 >= 0 ? index - 1 : total! - 1}`,
+            'prev',
           )
           .setLabel(`Prev`),
       );
@@ -735,7 +736,7 @@ export class Message {
     if (next || total) {
       group.push(
         new Component()
-          .setId(type, target ?? '', `${next ? `${index + 1}` : 0}`)
+          .setId(type, target ?? '', `${next ? `${index + 1}` : 0}`, 'next')
           .setLabel(`Next`),
       );
     }

--- a/tests/__snapshots__/interactions.test.ts.snap
+++ b/tests/__snapshots__/interactions.test.ts.snap
@@ -9,7 +9,7 @@ snapshot[`/help 1`] = `
       {
         components: [
           {
-            custom_id: "help==2",
+            custom_id: "help==2=prev",
             label: "Prev",
             style: 2,
             type: 2,
@@ -22,7 +22,7 @@ snapshot[`/help 1`] = `
             type: 2,
           },
           {
-            custom_id: "help==1",
+            custom_id: "help==1=next",
             label: "Next",
             style: 2,
             type: 2,
@@ -81,7 +81,7 @@ snapshot[`/help 2`] = `
       {
         components: [
           {
-            custom_id: "help==0",
+            custom_id: "help==0=prev",
             label: "Prev",
             style: 2,
             type: 2,
@@ -94,7 +94,7 @@ snapshot[`/help 2`] = `
             type: 2,
           },
           {
-            custom_id: "help==2",
+            custom_id: "help==2=next",
             label: "Next",
             style: 2,
             type: 2,
@@ -134,7 +134,7 @@ snapshot[`/help 3`] = `
       {
         components: [
           {
-            custom_id: "help==1",
+            custom_id: "help==1=prev",
             label: "Prev",
             style: 2,
             type: 2,
@@ -147,7 +147,7 @@ snapshot[`/help 3`] = `
             type: 2,
           },
           {
-            custom_id: "help==0",
+            custom_id: "help==0=next",
             label: "Next",
             style: 2,
             type: 2,

--- a/tests/discord.test.ts
+++ b/tests/discord.test.ts
@@ -495,7 +495,7 @@ Deno.test('page messages', async (test) => {
           type: 1,
           components: [
             {
-              custom_id: 'type=target=1',
+              custom_id: 'type=target=1=prev',
               label: 'Prev',
               style: 2,
               type: 2,
@@ -508,7 +508,7 @@ Deno.test('page messages', async (test) => {
               type: 2,
             },
             {
-              custom_id: 'type=target=1',
+              custom_id: 'type=target=1=next',
               label: 'Next',
               style: 2,
               type: 2,
@@ -542,7 +542,7 @@ Deno.test('page messages', async (test) => {
           type: 1,
           components: [
             {
-              custom_id: 'type=target=0',
+              custom_id: 'type=target=0=prev',
               label: 'Prev',
               style: 2,
               type: 2,
@@ -555,7 +555,7 @@ Deno.test('page messages', async (test) => {
               type: 2,
             },
             {
-              custom_id: 'type=target=0',
+              custom_id: 'type=target=0=next',
               label: 'Next',
               style: 2,
               type: 2,
@@ -588,7 +588,7 @@ Deno.test('page messages', async (test) => {
         components: [{
           type: 1,
           components: [{
-            custom_id: 'type=target=0',
+            custom_id: 'type=target=0=prev',
             label: 'Prev',
             style: 2,
             type: 2,
@@ -599,7 +599,7 @@ Deno.test('page messages', async (test) => {
             style: 2,
             type: 2,
           }, {
-            custom_id: 'type=target=2',
+            custom_id: 'type=target=2=next',
             label: 'Next',
             style: 2,
             type: 2,
@@ -636,7 +636,7 @@ Deno.test('page messages', async (test) => {
             style: 2,
             type: 2,
           }, {
-            custom_id: 'type=target=1',
+            custom_id: 'type=target=1=next',
             label: 'Next',
             style: 2,
             type: 2,
@@ -669,7 +669,7 @@ Deno.test('page messages', async (test) => {
           type: 1,
           components: [
             {
-              custom_id: 'type=target=0',
+              custom_id: 'type=target=0=prev',
               label: 'Prev',
               style: 2,
               type: 2,
@@ -682,7 +682,7 @@ Deno.test('page messages', async (test) => {
               type: 2,
             },
             {
-              custom_id: 'type=target=0',
+              custom_id: 'type=target=0=next',
               label: 'Next',
               style: 2,
               type: 2,

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -2796,7 +2796,7 @@ Deno.test('media characters', async (test) => {
                 type: 2,
               },
               {
-                custom_id: 'mcharacter=pack-id:1=1',
+                custom_id: 'mcharacter=pack-id:1=1=next',
                 label: 'Next',
                 style: 2,
                 type: 2,
@@ -2902,7 +2902,7 @@ Deno.test('media characters', async (test) => {
                 type: 2,
               },
               {
-                custom_id: 'mcharacter=pack-id:1=1',
+                custom_id: 'mcharacter=pack-id:1=1=next',
                 label: 'Next',
                 style: 2,
                 type: 2,
@@ -6015,7 +6015,7 @@ Deno.test('/packs [builtin-community]', async (test) => {
             type: 1,
             components: [
               {
-                custom_id: 'builtin==1',
+                custom_id: 'builtin==1=prev',
                 label: 'Prev',
                 style: 2,
                 type: 2,
@@ -6028,7 +6028,7 @@ Deno.test('/packs [builtin-community]', async (test) => {
                 type: 2,
               },
               {
-                custom_id: 'builtin==1',
+                custom_id: 'builtin==1=next',
                 label: 'Next',
                 style: 2,
                 type: 2,
@@ -6078,7 +6078,7 @@ Deno.test('/packs [builtin-community]', async (test) => {
             type: 1,
             components: [
               {
-                custom_id: 'community==0',
+                custom_id: 'community==0=prev',
                 label: 'Prev',
                 style: 2,
                 type: 2,
@@ -6091,7 +6091,7 @@ Deno.test('/packs [builtin-community]', async (test) => {
                 type: 2,
               },
               {
-                custom_id: 'community==0',
+                custom_id: 'community==0=next',
                 label: 'Next',
                 style: 2,
                 type: 2,
@@ -6142,7 +6142,7 @@ Deno.test('/packs [builtin-community]', async (test) => {
             type: 1,
             components: [
               {
-                custom_id: 'builtin==0',
+                custom_id: 'builtin==0=prev',
                 label: 'Prev',
                 style: 2,
                 type: 2,
@@ -6155,7 +6155,7 @@ Deno.test('/packs [builtin-community]', async (test) => {
                 type: 2,
               },
               {
-                custom_id: 'builtin==0',
+                custom_id: 'builtin==0=next',
                 label: 'Next',
                 style: 2,
                 type: 2,
@@ -6214,7 +6214,7 @@ Deno.test('/help', async (test) => {
     const message = help({ userId: 'user_id', index: 0 });
 
     assertEquals(message.json().data.components[0].components[0], {
-      custom_id: 'help==2',
+      custom_id: 'help==2=prev',
       label: 'Prev',
       style: 2,
       type: 2,
@@ -6229,7 +6229,7 @@ Deno.test('/help', async (test) => {
     });
 
     assertEquals(message.json().data.components[0].components[2], {
-      custom_id: 'help==1',
+      custom_id: 'help==1=next',
       label: 'Next',
       style: 2,
       type: 2,


### PR DESCRIPTION
- Fixed an error with the discord pages code
_There was an edge case that caused the prev and next buttons to have the same exact id and discord hates that, specifically of `/packs builtin` where is their only 2 pages, next and prev would always have the same id _