### PR TITLE
Hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,20 @@
   <img height="100" src="./assets/splash.png" alt="Fable Logo">
 </h1>
 
-<!-- User badges  -->
+<!-- Badges  -->
 
 <h1 align="center">
 
 [![top.gg votes](https://top.gg/api/widget/upvotes/1041970851559522304.svg?noavatar=true)](https://top.gg/bot/1041970851559522304/vote)
 [![top.gg page](https://top.gg/api/widget/servers/1041970851559522304.svg?noavatar=true)](https://top.gg/bot/1041970851559522304)
 
-[![Discord Bot Invite](https://img.shields.io/badge/Add%20Fable%20to%20Your%20Server-blue?style=for-the-badge&logo=discord&logoColor=white)](https://fable.deno.dev/invite)
+[![Discord Bot Invite](https://img.shields.io/badge/Add%20Fable%20to%20Your%20Server-blue?logo=discord&logoColor=white)](https://fable.deno.dev/invite)
+[![Fable Uptime Status](https://betteruptime.com/status-badges/v1/monitor/p925.svg)](https://fables.betteruptime.com)
+[![Discord Server](https://img.shields.io/discord/992416714497212518?label=discord%20server&color=blue)][discord]
 
-[![Discord Support Server](https://img.shields.io/discord/992416714497212518?label=Discord%20Support%20Server&style=for-the-badge)][discord]
-
-<!-- Development badges -->
-
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/ker0olos/fable/deno.yml?branch=main&style=for-the-badge&label=tests)
-[![codecov](https://img.shields.io/codecov/c/gh/ker0olos/fable/main?style=for-the-badge&token=3C7ZTHzGqC)](https://app.codecov.io/github/ker0olos/fable)
-![GitHub Last Commit](https://img.shields.io/github/last-commit/ker0olos/fable?style=for-the-badge&label=Last%20Update)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/ker0olos/fable/deno.yml?branch=main&label=tests)
+[![codecov](https://img.shields.io/codecov/c/gh/ker0olos/fable/main?token=3C7ZTHzGqC)](https://app.codecov.io/github/ker0olos/fable)
+![GitHub commit activity](https://img.shields.io/github/commit-activity/m/ker0olos/fable?color=blue&label=update%20frequency)
 
 </h1>
 
@@ -26,17 +24,21 @@
   <img align="right" width="250" src="https://user-images.githubusercontent.com/52022280/227321932-2ad8d36c-e56c-46e9-91da-161b79eeb029.gif" alt="Animated Pulls">
 </i>
 
-Fable is a free, open-source gacha bot — a simple, powerful Mudae alternative.
-Like Mudae, you can pull anime characters. Unlike Mudae, there are no premiums
-and no pay-to-win bullshit.
+Fable is a free, open-source gacha bot — a friendly, powerful alternative to
+bots like Mudae, Sofi, Karuta. Like those bots, you can pull anime characters,
+customize, and upgrade them.
 
 There's an intuitive system to manage and customize the characters in your
 servers, like adding extensions to chrome and installing apps on your phone, you
 can install community-made packs that are full of new characters with a single
 command.
 
-You can try an online demo of Fable before adding it to your server by going to
-<https://fable.deno.dev>
+Wanna make your own community pack? Check
+[fable-community/example](https://github.com/fable-community/fable-pack-example)
+for more information.
+
+You can try a basic online demo of Fable before inviting it to your server by
+going to <https://fable.deno.dev/demo>
 
 Fable is actively developed with new game modes and features frequently.
 
@@ -60,6 +62,7 @@ Fable is actively developed with new game modes and features frequently.
 - [Join our discord][discord]
 - Tell your favorite server's admins about us
 - [Contribute to the code][contributing]
+- [Sponsor the project][sponsoring]
 
 <br clear="right"/>
 
@@ -125,5 +128,23 @@ Use `/packs community` or `/packs uninstall id: pack-id`.
 </p>
 </details>
 
+<details><summary>How are you keeping Fable free?</summary>
+<p>
+
+We use serverless since it's cheaper and easier. Right now the bills are very
+small, but if it starts getting out of hand, we plan to rate limit servers on
+how much they can call Fable each month.
+
+We been very transparent from day one, if something happens we'll let known
+instantly.
+
+But we welcome any donations people are willing to throw us, since those the the
+final decider on how much control we have over our various bills, and how much
+time, and how many people are working on Fable at any giving moment.
+
+</p>
+</details>
+
 [discord]: https://discord.gg/ceKyEfhyPQ
+[sponsoring]: https://github.com/sponsors/ker0olos
 [contributing]: https://github.com/ker0olos/fable/wiki/Contributing

--- a/models/__snapshots__/add_character_to_inventory.test.ts.snap
+++ b/models/__snapshots__/add_character_to_inventory.test.ts.snap
@@ -454,39 +454,6 @@ snapshot[`model 2`] = `
                                                                         },
                                                                       },
                                                                     },
-                                                                    characters: Expr {
-                                                                      raw: {
-                                                                        append: Expr {
-                                                                          raw: {
-                                                                            from: Expr {
-                                                                              raw: {
-                                                                                var: "createdCharacter",
-                                                                              },
-                                                                            },
-                                                                            select: "ref",
-                                                                          },
-                                                                        },
-                                                                        collection: Expr {
-                                                                          raw: {
-                                                                            default: Expr {
-                                                                              raw: [
-                                                                              ],
-                                                                            },
-                                                                            from: Expr {
-                                                                              raw: {
-                                                                                var: "inventory",
-                                                                              },
-                                                                            },
-                                                                            select: Expr {
-                                                                              raw: [
-                                                                                "data",
-                                                                                "characters",
-                                                                              ],
-                                                                            },
-                                                                          },
-                                                                        },
-                                                                      },
-                                                                    },
                                                                     lastPull: Expr {
                                                                       raw: {
                                                                         now: null,
@@ -952,244 +919,6 @@ snapshot[`model 2`] = `
                                 },
                               },
                               {
-                                _inventory: Expr {
-                                  raw: {
-                                    in: Expr {
-                                      raw: {
-                                        else: Expr {
-                                          raw: {
-                                            in: Expr {
-                                              raw: {
-                                                var: "createdInventory",
-                                              },
-                                            },
-                                            let: [
-                                              {
-                                                createdInventory: Expr {
-                                                  raw: {
-                                                    create: Expr {
-                                                      raw: {
-                                                        collection: "inventory",
-                                                      },
-                                                    },
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
-                                                                instance: Expr {
-                                                                  raw: {
-                                                                    from: Expr {
-                                                                      raw: {
-                                                                        var: "instance",
-                                                                      },
-                                                                    },
-                                                                    select: "ref",
-                                                                  },
-                                                                },
-                                                                user: Expr {
-                                                                  raw: {
-                                                                    from: Expr {
-                                                                      raw: {
-                                                                        var: "user",
-                                                                      },
-                                                                    },
-                                                                    select: "ref",
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                              {
-                                                updatedInstance: Expr {
-                                                  raw: {
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                inventories: Expr {
-                                                                  raw: {
-                                                                    append: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "createdInventory",
-                                                                          },
-                                                                        },
-                                                                        select: "ref",
-                                                                      },
-                                                                    },
-                                                                    collection: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "instance",
-                                                                          },
-                                                                        },
-                                                                        select: Expr {
-                                                                          raw: [
-                                                                            "data",
-                                                                            "inventories",
-                                                                          ],
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                    update: Expr {
-                                                      raw: {
-                                                        from: Expr {
-                                                          raw: {
-                                                            var: "instance",
-                                                          },
-                                                        },
-                                                        select: "ref",
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                              {
-                                                updatedUser: Expr {
-                                                  raw: {
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                inventories: Expr {
-                                                                  raw: {
-                                                                    append: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "createdInventory",
-                                                                          },
-                                                                        },
-                                                                        select: "ref",
-                                                                      },
-                                                                    },
-                                                                    collection: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "user",
-                                                                          },
-                                                                        },
-                                                                        select: Expr {
-                                                                          raw: [
-                                                                            "data",
-                                                                            "inventories",
-                                                                          ],
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                    update: Expr {
-                                                      raw: {
-                                                        from: Expr {
-                                                          raw: {
-                                                            var: "user",
-                                                          },
-                                                        },
-                                                        select: "ref",
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                            ],
-                                          },
-                                        },
-                                        if: Expr {
-                                          raw: {
-                                            is_nonempty: Expr {
-                                              raw: {
-                                                var: "match",
-                                              },
-                                            },
-                                          },
-                                        },
-                                        then: Expr {
-                                          raw: {
-                                            get: Expr {
-                                              raw: {
-                                                var: "match",
-                                              },
-                                            },
-                                          },
-                                        },
-                                      },
-                                    },
-                                    let: [
-                                      {
-                                        match: Expr {
-                                          raw: {
-                                            match: Expr {
-                                              raw: {
-                                                index: "inventories_instance_user",
-                                              },
-                                            },
-                                            terms: Expr {
-                                              raw: [
-                                                Expr {
-                                                  raw: {
-                                                    from: Expr {
-                                                      raw: {
-                                                        var: "instance",
-                                                      },
-                                                    },
-                                                    select: "ref",
-                                                  },
-                                                },
-                                                Expr {
-                                                  raw: {
-                                                    from: Expr {
-                                                      raw: {
-                                                        var: "user",
-                                                      },
-                                                    },
-                                                    select: "ref",
-                                                  },
-                                                },
-                                              ],
-                                            },
-                                          },
-                                        },
-                                      },
-                                    ],
-                                  },
-                                },
-                              },
-                              {
                                 inventory: Expr {
                                   raw: {
                                     in: Expr {
@@ -1267,7 +996,234 @@ snapshot[`model 2`] = `
                                           raw: {
                                             from: Expr {
                                               raw: {
-                                                var: "_inventory",
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
                                               },
                                             },
                                             select: "ref",
@@ -1286,7 +1242,234 @@ snapshot[`model 2`] = `
                                             },
                                             from: Expr {
                                               raw: {
-                                                var: "_inventory",
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
                                               },
                                             },
                                             select: Expr {
@@ -1303,7 +1486,234 @@ snapshot[`model 2`] = `
                                           raw: {
                                             from: Expr {
                                               raw: {
-                                                var: "_inventory",
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
                                               },
                                             },
                                             select: Expr {
@@ -1787,39 +2197,6 @@ snapshot[`model 2`] = `
                                                                         },
                                                                       },
                                                                     },
-                                                                    characters: Expr {
-                                                                      raw: {
-                                                                        append: Expr {
-                                                                          raw: {
-                                                                            from: Expr {
-                                                                              raw: {
-                                                                                var: "createdCharacter",
-                                                                              },
-                                                                            },
-                                                                            select: "ref",
-                                                                          },
-                                                                        },
-                                                                        collection: Expr {
-                                                                          raw: {
-                                                                            default: Expr {
-                                                                              raw: [
-                                                                              ],
-                                                                            },
-                                                                            from: Expr {
-                                                                              raw: {
-                                                                                var: "inventory",
-                                                                              },
-                                                                            },
-                                                                            select: Expr {
-                                                                              raw: [
-                                                                                "data",
-                                                                                "characters",
-                                                                              ],
-                                                                            },
-                                                                          },
-                                                                        },
-                                                                      },
-                                                                    },
                                                                     lastPull: Expr {
                                                                       raw: {
                                                                         now: null,
@@ -2285,244 +2662,6 @@ snapshot[`model 2`] = `
                                 },
                               },
                               {
-                                _inventory: Expr {
-                                  raw: {
-                                    in: Expr {
-                                      raw: {
-                                        else: Expr {
-                                          raw: {
-                                            in: Expr {
-                                              raw: {
-                                                var: "createdInventory",
-                                              },
-                                            },
-                                            let: [
-                                              {
-                                                createdInventory: Expr {
-                                                  raw: {
-                                                    create: Expr {
-                                                      raw: {
-                                                        collection: "inventory",
-                                                      },
-                                                    },
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
-                                                                instance: Expr {
-                                                                  raw: {
-                                                                    from: Expr {
-                                                                      raw: {
-                                                                        var: "instance",
-                                                                      },
-                                                                    },
-                                                                    select: "ref",
-                                                                  },
-                                                                },
-                                                                user: Expr {
-                                                                  raw: {
-                                                                    from: Expr {
-                                                                      raw: {
-                                                                        var: "user",
-                                                                      },
-                                                                    },
-                                                                    select: "ref",
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                              {
-                                                updatedInstance: Expr {
-                                                  raw: {
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                inventories: Expr {
-                                                                  raw: {
-                                                                    append: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "createdInventory",
-                                                                          },
-                                                                        },
-                                                                        select: "ref",
-                                                                      },
-                                                                    },
-                                                                    collection: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "instance",
-                                                                          },
-                                                                        },
-                                                                        select: Expr {
-                                                                          raw: [
-                                                                            "data",
-                                                                            "inventories",
-                                                                          ],
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                    update: Expr {
-                                                      raw: {
-                                                        from: Expr {
-                                                          raw: {
-                                                            var: "instance",
-                                                          },
-                                                        },
-                                                        select: "ref",
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                              {
-                                                updatedUser: Expr {
-                                                  raw: {
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                inventories: Expr {
-                                                                  raw: {
-                                                                    append: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "createdInventory",
-                                                                          },
-                                                                        },
-                                                                        select: "ref",
-                                                                      },
-                                                                    },
-                                                                    collection: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "user",
-                                                                          },
-                                                                        },
-                                                                        select: Expr {
-                                                                          raw: [
-                                                                            "data",
-                                                                            "inventories",
-                                                                          ],
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                    update: Expr {
-                                                      raw: {
-                                                        from: Expr {
-                                                          raw: {
-                                                            var: "user",
-                                                          },
-                                                        },
-                                                        select: "ref",
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                            ],
-                                          },
-                                        },
-                                        if: Expr {
-                                          raw: {
-                                            is_nonempty: Expr {
-                                              raw: {
-                                                var: "match",
-                                              },
-                                            },
-                                          },
-                                        },
-                                        then: Expr {
-                                          raw: {
-                                            get: Expr {
-                                              raw: {
-                                                var: "match",
-                                              },
-                                            },
-                                          },
-                                        },
-                                      },
-                                    },
-                                    let: [
-                                      {
-                                        match: Expr {
-                                          raw: {
-                                            match: Expr {
-                                              raw: {
-                                                index: "inventories_instance_user",
-                                              },
-                                            },
-                                            terms: Expr {
-                                              raw: [
-                                                Expr {
-                                                  raw: {
-                                                    from: Expr {
-                                                      raw: {
-                                                        var: "instance",
-                                                      },
-                                                    },
-                                                    select: "ref",
-                                                  },
-                                                },
-                                                Expr {
-                                                  raw: {
-                                                    from: Expr {
-                                                      raw: {
-                                                        var: "user",
-                                                      },
-                                                    },
-                                                    select: "ref",
-                                                  },
-                                                },
-                                              ],
-                                            },
-                                          },
-                                        },
-                                      },
-                                    ],
-                                  },
-                                },
-                              },
-                              {
                                 inventory: Expr {
                                   raw: {
                                     in: Expr {
@@ -2600,7 +2739,234 @@ snapshot[`model 2`] = `
                                           raw: {
                                             from: Expr {
                                               raw: {
-                                                var: "_inventory",
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
                                               },
                                             },
                                             select: "ref",
@@ -2619,7 +2985,234 @@ snapshot[`model 2`] = `
                                             },
                                             from: Expr {
                                               raw: {
-                                                var: "_inventory",
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
                                               },
                                             },
                                             select: Expr {
@@ -2636,7 +3229,234 @@ snapshot[`model 2`] = `
                                           raw: {
                                             from: Expr {
                                               raw: {
-                                                var: "_inventory",
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
                                               },
                                             },
                                             select: Expr {

--- a/models/__snapshots__/add_vote_to_user.test.ts.snap
+++ b/models/__snapshots__/add_vote_to_user.test.ts.snap
@@ -1285,244 +1285,6 @@ snapshot[`model 2`] = `
                                 },
                               },
                               {
-                                _inventory: Expr {
-                                  raw: {
-                                    in: Expr {
-                                      raw: {
-                                        else: Expr {
-                                          raw: {
-                                            in: Expr {
-                                              raw: {
-                                                var: "createdInventory",
-                                              },
-                                            },
-                                            let: [
-                                              {
-                                                createdInventory: Expr {
-                                                  raw: {
-                                                    create: Expr {
-                                                      raw: {
-                                                        collection: "inventory",
-                                                      },
-                                                    },
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
-                                                                instance: Expr {
-                                                                  raw: {
-                                                                    from: Expr {
-                                                                      raw: {
-                                                                        var: "instance",
-                                                                      },
-                                                                    },
-                                                                    select: "ref",
-                                                                  },
-                                                                },
-                                                                user: Expr {
-                                                                  raw: {
-                                                                    from: Expr {
-                                                                      raw: {
-                                                                        var: "user",
-                                                                      },
-                                                                    },
-                                                                    select: "ref",
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                              {
-                                                updatedInstance: Expr {
-                                                  raw: {
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                inventories: Expr {
-                                                                  raw: {
-                                                                    append: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "createdInventory",
-                                                                          },
-                                                                        },
-                                                                        select: "ref",
-                                                                      },
-                                                                    },
-                                                                    collection: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "instance",
-                                                                          },
-                                                                        },
-                                                                        select: Expr {
-                                                                          raw: [
-                                                                            "data",
-                                                                            "inventories",
-                                                                          ],
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                    update: Expr {
-                                                      raw: {
-                                                        from: Expr {
-                                                          raw: {
-                                                            var: "instance",
-                                                          },
-                                                        },
-                                                        select: "ref",
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                              {
-                                                updatedUser: Expr {
-                                                  raw: {
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                inventories: Expr {
-                                                                  raw: {
-                                                                    append: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "createdInventory",
-                                                                          },
-                                                                        },
-                                                                        select: "ref",
-                                                                      },
-                                                                    },
-                                                                    collection: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "user",
-                                                                          },
-                                                                        },
-                                                                        select: Expr {
-                                                                          raw: [
-                                                                            "data",
-                                                                            "inventories",
-                                                                          ],
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                    update: Expr {
-                                                      raw: {
-                                                        from: Expr {
-                                                          raw: {
-                                                            var: "user",
-                                                          },
-                                                        },
-                                                        select: "ref",
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                            ],
-                                          },
-                                        },
-                                        if: Expr {
-                                          raw: {
-                                            is_nonempty: Expr {
-                                              raw: {
-                                                var: "match",
-                                              },
-                                            },
-                                          },
-                                        },
-                                        then: Expr {
-                                          raw: {
-                                            get: Expr {
-                                              raw: {
-                                                var: "match",
-                                              },
-                                            },
-                                          },
-                                        },
-                                      },
-                                    },
-                                    let: [
-                                      {
-                                        match: Expr {
-                                          raw: {
-                                            match: Expr {
-                                              raw: {
-                                                index: "inventories_instance_user",
-                                              },
-                                            },
-                                            terms: Expr {
-                                              raw: [
-                                                Expr {
-                                                  raw: {
-                                                    from: Expr {
-                                                      raw: {
-                                                        var: "instance",
-                                                      },
-                                                    },
-                                                    select: "ref",
-                                                  },
-                                                },
-                                                Expr {
-                                                  raw: {
-                                                    from: Expr {
-                                                      raw: {
-                                                        var: "user",
-                                                      },
-                                                    },
-                                                    select: "ref",
-                                                  },
-                                                },
-                                              ],
-                                            },
-                                          },
-                                        },
-                                      },
-                                    ],
-                                  },
-                                },
-                              },
-                              {
                                 inventory: Expr {
                                   raw: {
                                     in: Expr {
@@ -1600,7 +1362,234 @@ snapshot[`model 2`] = `
                                           raw: {
                                             from: Expr {
                                               raw: {
-                                                var: "_inventory",
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
                                               },
                                             },
                                             select: "ref",
@@ -1619,7 +1608,234 @@ snapshot[`model 2`] = `
                                             },
                                             from: Expr {
                                               raw: {
-                                                var: "_inventory",
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
                                               },
                                             },
                                             select: Expr {
@@ -1636,7 +1852,234 @@ snapshot[`model 2`] = `
                                           raw: {
                                             from: Expr {
                                               raw: {
-                                                var: "_inventory",
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
                                               },
                                             },
                                             select: Expr {
@@ -2274,244 +2717,6 @@ snapshot[`model 2`] = `
                                 },
                               },
                               {
-                                _inventory: Expr {
-                                  raw: {
-                                    in: Expr {
-                                      raw: {
-                                        else: Expr {
-                                          raw: {
-                                            in: Expr {
-                                              raw: {
-                                                var: "createdInventory",
-                                              },
-                                            },
-                                            let: [
-                                              {
-                                                createdInventory: Expr {
-                                                  raw: {
-                                                    create: Expr {
-                                                      raw: {
-                                                        collection: "inventory",
-                                                      },
-                                                    },
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
-                                                                instance: Expr {
-                                                                  raw: {
-                                                                    from: Expr {
-                                                                      raw: {
-                                                                        var: "instance",
-                                                                      },
-                                                                    },
-                                                                    select: "ref",
-                                                                  },
-                                                                },
-                                                                user: Expr {
-                                                                  raw: {
-                                                                    from: Expr {
-                                                                      raw: {
-                                                                        var: "user",
-                                                                      },
-                                                                    },
-                                                                    select: "ref",
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                              {
-                                                updatedInstance: Expr {
-                                                  raw: {
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                inventories: Expr {
-                                                                  raw: {
-                                                                    append: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "createdInventory",
-                                                                          },
-                                                                        },
-                                                                        select: "ref",
-                                                                      },
-                                                                    },
-                                                                    collection: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "instance",
-                                                                          },
-                                                                        },
-                                                                        select: Expr {
-                                                                          raw: [
-                                                                            "data",
-                                                                            "inventories",
-                                                                          ],
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                    update: Expr {
-                                                      raw: {
-                                                        from: Expr {
-                                                          raw: {
-                                                            var: "instance",
-                                                          },
-                                                        },
-                                                        select: "ref",
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                              {
-                                                updatedUser: Expr {
-                                                  raw: {
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                inventories: Expr {
-                                                                  raw: {
-                                                                    append: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "createdInventory",
-                                                                          },
-                                                                        },
-                                                                        select: "ref",
-                                                                      },
-                                                                    },
-                                                                    collection: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "user",
-                                                                          },
-                                                                        },
-                                                                        select: Expr {
-                                                                          raw: [
-                                                                            "data",
-                                                                            "inventories",
-                                                                          ],
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                    update: Expr {
-                                                      raw: {
-                                                        from: Expr {
-                                                          raw: {
-                                                            var: "user",
-                                                          },
-                                                        },
-                                                        select: "ref",
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                            ],
-                                          },
-                                        },
-                                        if: Expr {
-                                          raw: {
-                                            is_nonempty: Expr {
-                                              raw: {
-                                                var: "match",
-                                              },
-                                            },
-                                          },
-                                        },
-                                        then: Expr {
-                                          raw: {
-                                            get: Expr {
-                                              raw: {
-                                                var: "match",
-                                              },
-                                            },
-                                          },
-                                        },
-                                      },
-                                    },
-                                    let: [
-                                      {
-                                        match: Expr {
-                                          raw: {
-                                            match: Expr {
-                                              raw: {
-                                                index: "inventories_instance_user",
-                                              },
-                                            },
-                                            terms: Expr {
-                                              raw: [
-                                                Expr {
-                                                  raw: {
-                                                    from: Expr {
-                                                      raw: {
-                                                        var: "instance",
-                                                      },
-                                                    },
-                                                    select: "ref",
-                                                  },
-                                                },
-                                                Expr {
-                                                  raw: {
-                                                    from: Expr {
-                                                      raw: {
-                                                        var: "user",
-                                                      },
-                                                    },
-                                                    select: "ref",
-                                                  },
-                                                },
-                                              ],
-                                            },
-                                          },
-                                        },
-                                      },
-                                    ],
-                                  },
-                                },
-                              },
-                              {
                                 inventory: Expr {
                                   raw: {
                                     in: Expr {
@@ -2589,7 +2794,234 @@ snapshot[`model 2`] = `
                                           raw: {
                                             from: Expr {
                                               raw: {
-                                                var: "_inventory",
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
                                               },
                                             },
                                             select: "ref",
@@ -2608,7 +3040,234 @@ snapshot[`model 2`] = `
                                             },
                                             from: Expr {
                                               raw: {
-                                                var: "_inventory",
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
                                               },
                                             },
                                             select: Expr {
@@ -2625,7 +3284,234 @@ snapshot[`model 2`] = `
                                           raw: {
                                             from: Expr {
                                               raw: {
-                                                var: "_inventory",
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
                                               },
                                             },
                                             select: Expr {

--- a/models/__snapshots__/customize_character.test.ts.snap
+++ b/models/__snapshots__/customize_character.test.ts.snap
@@ -632,10 +632,6 @@ snapshot[`model 1`] = `
                                                             raw: {
                                                               object: {
                                                                 availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
                                                                 instance: Expr {
                                                                   raw: {
                                                                     from: Expr {
@@ -1501,10 +1497,6 @@ snapshot[`model 1`] = `
                                                             raw: {
                                                               object: {
                                                                 availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
                                                                 instance: Expr {
                                                                   raw: {
                                                                     from: Expr {

--- a/models/__snapshots__/get_user_inventory.test.ts.snap
+++ b/models/__snapshots__/get_user_inventory.test.ts.snap
@@ -303,6 +303,97 @@ snapshot[`model 4`] = `
     raw: {
       else: Expr {
         raw: {
+          create_index: Expr {
+            raw: {
+              object: {
+                name: "inventory_characters",
+                source: Expr {
+                  raw: {
+                    collection: "character",
+                  },
+                },
+                terms: Expr {
+                  raw: [
+                    Expr {
+                      raw: {
+                        object: {
+                          field: Expr {
+                            raw: [
+                              "data",
+                              "inventory",
+                            ],
+                          },
+                        },
+                      },
+                    },
+                  ],
+                },
+                unique: false,
+                values: undefined,
+              },
+            },
+          },
+        },
+      },
+      if: Expr {
+        raw: {
+          exists: Expr {
+            raw: {
+              index: "inventory_characters",
+            },
+          },
+        },
+      },
+      then: Expr {
+        raw: {
+          params: Expr {
+            raw: {
+              object: {
+                name: "inventory_characters",
+                source: Expr {
+                  raw: {
+                    collection: "character",
+                  },
+                },
+                terms: Expr {
+                  raw: [
+                    Expr {
+                      raw: {
+                        object: {
+                          field: Expr {
+                            raw: [
+                              "data",
+                              "inventory",
+                            ],
+                          },
+                        },
+                      },
+                    },
+                  ],
+                },
+                unique: false,
+                values: undefined,
+              },
+            },
+          },
+          update: Expr {
+            raw: {
+              index: "inventory_characters",
+            },
+          },
+        },
+      },
+    },
+  },
+]
+`;
+
+snapshot[`model 5`] = `
+[
+  Expr {
+    raw: {
+      else: Expr {
+        raw: {
           create_function: Expr {
             raw: {
               object: {
@@ -822,7 +913,7 @@ snapshot[`model 4`] = `
 ]
 `;
 
-snapshot[`model 5`] = `
+snapshot[`model 6`] = `
 [
   Expr {
     raw: {
@@ -841,200 +932,73 @@ snapshot[`model 5`] = `
                               raw: {
                                 in: Expr {
                                   raw: {
-                                    params: Expr {
-                                      raw: {
-                                        object: {
-                                          data: Expr {
+                                    object: {
+                                      data: Expr {
+                                        raw: {
+                                          merge: Expr {
+                                            raw: {
+                                              from: Expr {
+                                                raw: {
+                                                  var: "inventory",
+                                                },
+                                              },
+                                              select: Expr {
+                                                raw: [
+                                                  "data",
+                                                ],
+                                              },
+                                            },
+                                          },
+                                          with: Expr {
                                             raw: {
                                               object: {
-                                                availablePulls: Expr {
+                                                characters: Expr {
                                                   raw: {
-                                                    min: Expr {
-                                                      raw: [
-                                                        99,
-                                                        Expr {
+                                                    from: Expr {
+                                                      raw: {
+                                                        after: undefined,
+                                                        before: undefined,
+                                                        paginate: Expr {
                                                           raw: {
-                                                            var: "rechargedPulls",
+                                                            var: "match",
                                                           },
                                                         },
+                                                        size: 9999,
+                                                      },
+                                                    },
+                                                    select: Expr {
+                                                      raw: [
+                                                        "data",
                                                       ],
                                                     },
-                                                  },
-                                                },
-                                                rechargeTimestamp: Expr {
-                                                  raw: {
-                                                    else: Expr {
-                                                      raw: {
-                                                        offset: Expr {
-                                                          raw: {
-                                                            multiply: Expr {
-                                                              raw: [
-                                                                Expr {
-                                                                  raw: {
-                                                                    var: "newPulls",
-                                                                  },
-                                                                },
-                                                                30,
-                                                              ],
-                                                            },
-                                                          },
-                                                        },
-                                                        time_add: Expr {
-                                                          raw: {
-                                                            var: "rechargeTimestamp",
-                                                          },
-                                                        },
-                                                        unit: "minutes",
-                                                      },
-                                                    },
-                                                    if: Expr {
-                                                      raw: {
-                                                        gte: Expr {
-                                                          raw: [
-                                                            Expr {
-                                                              raw: {
-                                                                var: "rechargedPulls",
-                                                              },
-                                                            },
-                                                            5,
-                                                          ],
-                                                        },
-                                                      },
-                                                    },
-                                                    then: null,
                                                   },
                                                 },
                                               },
                                             },
                                           },
                                         },
-                                      },
-                                    },
-                                    update: Expr {
-                                      raw: {
-                                        from: Expr {
-                                          raw: {
-                                            var: "inventory",
-                                          },
-                                        },
-                                        select: "ref",
                                       },
                                     },
                                   },
                                 },
                                 let: [
                                   {
-                                    rechargeTimestamp: Expr {
+                                    match: Expr {
                                       raw: {
-                                        default: Expr {
+                                        match: Expr {
                                           raw: {
-                                            now: null,
+                                            index: "inventory_characters",
                                           },
                                         },
-                                        from: Expr {
+                                        terms: Expr {
                                           raw: {
-                                            var: "inventory",
+                                            from: Expr {
+                                              raw: {
+                                                var: "inventory",
+                                              },
+                                            },
+                                            select: "ref",
                                           },
-                                        },
-                                        select: Expr {
-                                          raw: [
-                                            "data",
-                                            "rechargeTimestamp",
-                                          ],
-                                        },
-                                      },
-                                    },
-                                  },
-                                  {
-                                    currentPulls: Expr {
-                                      raw: {
-                                        from: Expr {
-                                          raw: {
-                                            var: "inventory",
-                                          },
-                                        },
-                                        select: Expr {
-                                          raw: [
-                                            "data",
-                                            "availablePulls",
-                                          ],
-                                        },
-                                      },
-                                    },
-                                  },
-                                  {
-                                    newPulls: Expr {
-                                      raw: {
-                                        max: Expr {
-                                          raw: [
-                                            0,
-                                            Expr {
-                                              raw: {
-                                                min: Expr {
-                                                  raw: [
-                                                    Expr {
-                                                      raw: {
-                                                        subtract: Expr {
-                                                          raw: [
-                                                            5,
-                                                            Expr {
-                                                              raw: {
-                                                                var: "currentPulls",
-                                                              },
-                                                            },
-                                                          ],
-                                                        },
-                                                      },
-                                                    },
-                                                    Expr {
-                                                      raw: {
-                                                        divide: Expr {
-                                                          raw: [
-                                                            Expr {
-                                                              raw: {
-                                                                other: Expr {
-                                                                  raw: {
-                                                                    now: null,
-                                                                  },
-                                                                },
-                                                                time_diff: Expr {
-                                                                  raw: {
-                                                                    var: "rechargeTimestamp",
-                                                                  },
-                                                                },
-                                                                unit: "minutes",
-                                                              },
-                                                            },
-                                                            30,
-                                                          ],
-                                                        },
-                                                      },
-                                                    },
-                                                  ],
-                                                },
-                                              },
-                                            },
-                                          ],
-                                        },
-                                      },
-                                    },
-                                  },
-                                  {
-                                    rechargedPulls: Expr {
-                                      raw: {
-                                        add: Expr {
-                                          raw: [
-                                            Expr {
-                                              raw: {
-                                                var: "currentPulls",
-                                              },
-                                            },
-                                            Expr {
-                                              raw: {
-                                                var: "newPulls",
-                                              },
-                                            },
-                                          ],
                                         },
                                       },
                                     },
@@ -1365,34 +1329,178 @@ snapshot[`model 5`] = `
                                   raw: {
                                     in: Expr {
                                       raw: {
-                                        else: Expr {
+                                        params: Expr {
                                           raw: {
-                                            in: Expr {
-                                              raw: {
-                                                var: "createdInventory",
-                                              },
-                                            },
-                                            let: [
-                                              {
-                                                createdInventory: Expr {
-                                                  raw: {
-                                                    create: Expr {
+                                            object: {
+                                              data: Expr {
+                                                raw: {
+                                                  object: {
+                                                    availablePulls: Expr {
                                                       raw: {
-                                                        collection: "inventory",
+                                                        min: Expr {
+                                                          raw: [
+                                                            99,
+                                                            Expr {
+                                                              raw: {
+                                                                var: "rechargedPulls",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
                                                       },
                                                     },
-                                                    params: Expr {
+                                                    rechargeTimestamp: Expr {
                                                       raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                availablePulls: 5,
-                                                                characters: Expr {
+                                                        else: Expr {
+                                                          raw: {
+                                                            offset: Expr {
+                                                              raw: {
+                                                                multiply: Expr {
                                                                   raw: [
+                                                                    Expr {
+                                                                      raw: {
+                                                                        var: "newPulls",
+                                                                      },
+                                                                    },
+                                                                    30,
                                                                   ],
                                                                 },
-                                                                instance: Expr {
+                                                              },
+                                                            },
+                                                            time_add: Expr {
+                                                              raw: {
+                                                                var: "rechargeTimestamp",
+                                                              },
+                                                            },
+                                                            unit: "minutes",
+                                                          },
+                                                        },
+                                                        if: Expr {
+                                                          raw: {
+                                                            gte: Expr {
+                                                              raw: [
+                                                                Expr {
+                                                                  raw: {
+                                                                    var: "rechargedPulls",
+                                                                  },
+                                                                },
+                                                                5,
+                                                              ],
+                                                            },
+                                                          },
+                                                        },
+                                                        then: null,
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                              },
+                                            },
+                                          },
+                                        },
+                                        update: Expr {
+                                          raw: {
+                                            from: Expr {
+                                              raw: {
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
                                                                   raw: {
                                                                     from: Expr {
                                                                       raw: {
@@ -1402,7 +1510,54 @@ snapshot[`model 5`] = `
                                                                     select: "ref",
                                                                   },
                                                                 },
-                                                                user: Expr {
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
                                                                   raw: {
                                                                     from: Expr {
                                                                       raw: {
@@ -1415,178 +1570,637 @@ snapshot[`model 5`] = `
                                                               },
                                                             },
                                                           },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
                                                         },
                                                       },
                                                     },
                                                   },
                                                 },
-                                              },
-                                              {
-                                                updatedInstance: Expr {
-                                                  raw: {
-                                                    params: Expr {
+                                                let: [
+                                                  {
+                                                    match: Expr {
                                                       raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                inventories: Expr {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
                                                                   raw: {
-                                                                    append: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "createdInventory",
-                                                                          },
-                                                                        },
-                                                                        select: "ref",
-                                                                      },
-                                                                    },
-                                                                    collection: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "instance",
-                                                                          },
-                                                                        },
-                                                                        select: Expr {
-                                                                          raw: [
-                                                                            "data",
-                                                                            "inventories",
-                                                                          ],
-                                                                        },
-                                                                      },
-                                                                    },
+                                                                    var: "instance",
                                                                   },
                                                                 },
+                                                                select: "ref",
                                                               },
                                                             },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                    update: Expr {
-                                                      raw: {
-                                                        from: Expr {
-                                                          raw: {
-                                                            var: "instance",
-                                                          },
-                                                        },
-                                                        select: "ref",
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                              {
-                                                updatedUser: Expr {
-                                                  raw: {
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                inventories: Expr {
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
                                                                   raw: {
-                                                                    append: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "createdInventory",
-                                                                          },
-                                                                        },
-                                                                        select: "ref",
-                                                                      },
-                                                                    },
-                                                                    collection: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "user",
-                                                                          },
-                                                                        },
-                                                                        select: Expr {
-                                                                          raw: [
-                                                                            "data",
-                                                                            "inventories",
-                                                                          ],
-                                                                        },
-                                                                      },
-                                                                    },
+                                                                    var: "user",
                                                                   },
                                                                 },
+                                                                select: "ref",
                                                               },
                                                             },
-                                                          },
+                                                          ],
                                                         },
-                                                      },
-                                                    },
-                                                    update: Expr {
-                                                      raw: {
-                                                        from: Expr {
-                                                          raw: {
-                                                            var: "user",
-                                                          },
-                                                        },
-                                                        select: "ref",
                                                       },
                                                     },
                                                   },
-                                                },
-                                              },
-                                            ],
-                                          },
-                                        },
-                                        if: Expr {
-                                          raw: {
-                                            is_nonempty: Expr {
-                                              raw: {
-                                                var: "match",
+                                                ],
                                               },
                                             },
-                                          },
-                                        },
-                                        then: Expr {
-                                          raw: {
-                                            get: Expr {
-                                              raw: {
-                                                var: "match",
-                                              },
-                                            },
+                                            select: "ref",
                                           },
                                         },
                                       },
                                     },
                                     let: [
                                       {
-                                        match: Expr {
+                                        rechargeTimestamp: Expr {
                                           raw: {
-                                            match: Expr {
+                                            default: Expr {
                                               raw: {
-                                                index: "inventories_instance_user",
+                                                now: null,
                                               },
                                             },
-                                            terms: Expr {
+                                            from: Expr {
+                                              raw: {
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
+                                              },
+                                            },
+                                            select: Expr {
+                                              raw: [
+                                                "data",
+                                                "rechargeTimestamp",
+                                              ],
+                                            },
+                                          },
+                                        },
+                                      },
+                                      {
+                                        currentPulls: Expr {
+                                          raw: {
+                                            from: Expr {
+                                              raw: {
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
+                                              },
+                                            },
+                                            select: Expr {
+                                              raw: [
+                                                "data",
+                                                "availablePulls",
+                                              ],
+                                            },
+                                          },
+                                        },
+                                      },
+                                      {
+                                        newPulls: Expr {
+                                          raw: {
+                                            max: Expr {
+                                              raw: [
+                                                0,
+                                                Expr {
+                                                  raw: {
+                                                    min: Expr {
+                                                      raw: [
+                                                        Expr {
+                                                          raw: {
+                                                            subtract: Expr {
+                                                              raw: [
+                                                                5,
+                                                                Expr {
+                                                                  raw: {
+                                                                    var: "currentPulls",
+                                                                  },
+                                                                },
+                                                              ],
+                                                            },
+                                                          },
+                                                        },
+                                                        Expr {
+                                                          raw: {
+                                                            divide: Expr {
+                                                              raw: [
+                                                                Expr {
+                                                                  raw: {
+                                                                    other: Expr {
+                                                                      raw: {
+                                                                        now: null,
+                                                                      },
+                                                                    },
+                                                                    time_diff: Expr {
+                                                                      raw: {
+                                                                        var: "rechargeTimestamp",
+                                                                      },
+                                                                    },
+                                                                    unit: "minutes",
+                                                                  },
+                                                                },
+                                                                30,
+                                                              ],
+                                                            },
+                                                          },
+                                                        },
+                                                      ],
+                                                    },
+                                                  },
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        },
+                                      },
+                                      {
+                                        rechargedPulls: Expr {
+                                          raw: {
+                                            add: Expr {
                                               raw: [
                                                 Expr {
                                                   raw: {
-                                                    from: Expr {
-                                                      raw: {
-                                                        var: "instance",
-                                                      },
-                                                    },
-                                                    select: "ref",
+                                                    var: "currentPulls",
                                                   },
                                                 },
                                                 Expr {
                                                   raw: {
-                                                    from: Expr {
-                                                      raw: {
-                                                        var: "user",
-                                                      },
-                                                    },
-                                                    select: "ref",
+                                                    var: "newPulls",
                                                   },
                                                 },
                                               ],
@@ -1641,200 +2255,73 @@ snapshot[`model 5`] = `
                               raw: {
                                 in: Expr {
                                   raw: {
-                                    params: Expr {
-                                      raw: {
-                                        object: {
-                                          data: Expr {
+                                    object: {
+                                      data: Expr {
+                                        raw: {
+                                          merge: Expr {
+                                            raw: {
+                                              from: Expr {
+                                                raw: {
+                                                  var: "inventory",
+                                                },
+                                              },
+                                              select: Expr {
+                                                raw: [
+                                                  "data",
+                                                ],
+                                              },
+                                            },
+                                          },
+                                          with: Expr {
                                             raw: {
                                               object: {
-                                                availablePulls: Expr {
+                                                characters: Expr {
                                                   raw: {
-                                                    min: Expr {
-                                                      raw: [
-                                                        99,
-                                                        Expr {
+                                                    from: Expr {
+                                                      raw: {
+                                                        after: undefined,
+                                                        before: undefined,
+                                                        paginate: Expr {
                                                           raw: {
-                                                            var: "rechargedPulls",
+                                                            var: "match",
                                                           },
                                                         },
+                                                        size: 9999,
+                                                      },
+                                                    },
+                                                    select: Expr {
+                                                      raw: [
+                                                        "data",
                                                       ],
                                                     },
-                                                  },
-                                                },
-                                                rechargeTimestamp: Expr {
-                                                  raw: {
-                                                    else: Expr {
-                                                      raw: {
-                                                        offset: Expr {
-                                                          raw: {
-                                                            multiply: Expr {
-                                                              raw: [
-                                                                Expr {
-                                                                  raw: {
-                                                                    var: "newPulls",
-                                                                  },
-                                                                },
-                                                                30,
-                                                              ],
-                                                            },
-                                                          },
-                                                        },
-                                                        time_add: Expr {
-                                                          raw: {
-                                                            var: "rechargeTimestamp",
-                                                          },
-                                                        },
-                                                        unit: "minutes",
-                                                      },
-                                                    },
-                                                    if: Expr {
-                                                      raw: {
-                                                        gte: Expr {
-                                                          raw: [
-                                                            Expr {
-                                                              raw: {
-                                                                var: "rechargedPulls",
-                                                              },
-                                                            },
-                                                            5,
-                                                          ],
-                                                        },
-                                                      },
-                                                    },
-                                                    then: null,
                                                   },
                                                 },
                                               },
                                             },
                                           },
                                         },
-                                      },
-                                    },
-                                    update: Expr {
-                                      raw: {
-                                        from: Expr {
-                                          raw: {
-                                            var: "inventory",
-                                          },
-                                        },
-                                        select: "ref",
                                       },
                                     },
                                   },
                                 },
                                 let: [
                                   {
-                                    rechargeTimestamp: Expr {
+                                    match: Expr {
                                       raw: {
-                                        default: Expr {
+                                        match: Expr {
                                           raw: {
-                                            now: null,
+                                            index: "inventory_characters",
                                           },
                                         },
-                                        from: Expr {
+                                        terms: Expr {
                                           raw: {
-                                            var: "inventory",
+                                            from: Expr {
+                                              raw: {
+                                                var: "inventory",
+                                              },
+                                            },
+                                            select: "ref",
                                           },
-                                        },
-                                        select: Expr {
-                                          raw: [
-                                            "data",
-                                            "rechargeTimestamp",
-                                          ],
-                                        },
-                                      },
-                                    },
-                                  },
-                                  {
-                                    currentPulls: Expr {
-                                      raw: {
-                                        from: Expr {
-                                          raw: {
-                                            var: "inventory",
-                                          },
-                                        },
-                                        select: Expr {
-                                          raw: [
-                                            "data",
-                                            "availablePulls",
-                                          ],
-                                        },
-                                      },
-                                    },
-                                  },
-                                  {
-                                    newPulls: Expr {
-                                      raw: {
-                                        max: Expr {
-                                          raw: [
-                                            0,
-                                            Expr {
-                                              raw: {
-                                                min: Expr {
-                                                  raw: [
-                                                    Expr {
-                                                      raw: {
-                                                        subtract: Expr {
-                                                          raw: [
-                                                            5,
-                                                            Expr {
-                                                              raw: {
-                                                                var: "currentPulls",
-                                                              },
-                                                            },
-                                                          ],
-                                                        },
-                                                      },
-                                                    },
-                                                    Expr {
-                                                      raw: {
-                                                        divide: Expr {
-                                                          raw: [
-                                                            Expr {
-                                                              raw: {
-                                                                other: Expr {
-                                                                  raw: {
-                                                                    now: null,
-                                                                  },
-                                                                },
-                                                                time_diff: Expr {
-                                                                  raw: {
-                                                                    var: "rechargeTimestamp",
-                                                                  },
-                                                                },
-                                                                unit: "minutes",
-                                                              },
-                                                            },
-                                                            30,
-                                                          ],
-                                                        },
-                                                      },
-                                                    },
-                                                  ],
-                                                },
-                                              },
-                                            },
-                                          ],
-                                        },
-                                      },
-                                    },
-                                  },
-                                  {
-                                    rechargedPulls: Expr {
-                                      raw: {
-                                        add: Expr {
-                                          raw: [
-                                            Expr {
-                                              raw: {
-                                                var: "currentPulls",
-                                              },
-                                            },
-                                            Expr {
-                                              raw: {
-                                                var: "newPulls",
-                                              },
-                                            },
-                                          ],
                                         },
                                       },
                                     },
@@ -2165,34 +2652,178 @@ snapshot[`model 5`] = `
                                   raw: {
                                     in: Expr {
                                       raw: {
-                                        else: Expr {
+                                        params: Expr {
                                           raw: {
-                                            in: Expr {
-                                              raw: {
-                                                var: "createdInventory",
-                                              },
-                                            },
-                                            let: [
-                                              {
-                                                createdInventory: Expr {
-                                                  raw: {
-                                                    create: Expr {
+                                            object: {
+                                              data: Expr {
+                                                raw: {
+                                                  object: {
+                                                    availablePulls: Expr {
                                                       raw: {
-                                                        collection: "inventory",
+                                                        min: Expr {
+                                                          raw: [
+                                                            99,
+                                                            Expr {
+                                                              raw: {
+                                                                var: "rechargedPulls",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
                                                       },
                                                     },
-                                                    params: Expr {
+                                                    rechargeTimestamp: Expr {
                                                       raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                availablePulls: 5,
-                                                                characters: Expr {
+                                                        else: Expr {
+                                                          raw: {
+                                                            offset: Expr {
+                                                              raw: {
+                                                                multiply: Expr {
                                                                   raw: [
+                                                                    Expr {
+                                                                      raw: {
+                                                                        var: "newPulls",
+                                                                      },
+                                                                    },
+                                                                    30,
                                                                   ],
                                                                 },
-                                                                instance: Expr {
+                                                              },
+                                                            },
+                                                            time_add: Expr {
+                                                              raw: {
+                                                                var: "rechargeTimestamp",
+                                                              },
+                                                            },
+                                                            unit: "minutes",
+                                                          },
+                                                        },
+                                                        if: Expr {
+                                                          raw: {
+                                                            gte: Expr {
+                                                              raw: [
+                                                                Expr {
+                                                                  raw: {
+                                                                    var: "rechargedPulls",
+                                                                  },
+                                                                },
+                                                                5,
+                                                              ],
+                                                            },
+                                                          },
+                                                        },
+                                                        then: null,
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                              },
+                                            },
+                                          },
+                                        },
+                                        update: Expr {
+                                          raw: {
+                                            from: Expr {
+                                              raw: {
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
                                                                   raw: {
                                                                     from: Expr {
                                                                       raw: {
@@ -2202,7 +2833,54 @@ snapshot[`model 5`] = `
                                                                     select: "ref",
                                                                   },
                                                                 },
-                                                                user: Expr {
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
                                                                   raw: {
                                                                     from: Expr {
                                                                       raw: {
@@ -2215,178 +2893,637 @@ snapshot[`model 5`] = `
                                                               },
                                                             },
                                                           },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
                                                         },
                                                       },
                                                     },
                                                   },
                                                 },
-                                              },
-                                              {
-                                                updatedInstance: Expr {
-                                                  raw: {
-                                                    params: Expr {
+                                                let: [
+                                                  {
+                                                    match: Expr {
                                                       raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                inventories: Expr {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
                                                                   raw: {
-                                                                    append: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "createdInventory",
-                                                                          },
-                                                                        },
-                                                                        select: "ref",
-                                                                      },
-                                                                    },
-                                                                    collection: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "instance",
-                                                                          },
-                                                                        },
-                                                                        select: Expr {
-                                                                          raw: [
-                                                                            "data",
-                                                                            "inventories",
-                                                                          ],
-                                                                        },
-                                                                      },
-                                                                    },
+                                                                    var: "instance",
                                                                   },
                                                                 },
+                                                                select: "ref",
                                                               },
                                                             },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                    update: Expr {
-                                                      raw: {
-                                                        from: Expr {
-                                                          raw: {
-                                                            var: "instance",
-                                                          },
-                                                        },
-                                                        select: "ref",
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                              {
-                                                updatedUser: Expr {
-                                                  raw: {
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                inventories: Expr {
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
                                                                   raw: {
-                                                                    append: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "createdInventory",
-                                                                          },
-                                                                        },
-                                                                        select: "ref",
-                                                                      },
-                                                                    },
-                                                                    collection: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "user",
-                                                                          },
-                                                                        },
-                                                                        select: Expr {
-                                                                          raw: [
-                                                                            "data",
-                                                                            "inventories",
-                                                                          ],
-                                                                        },
-                                                                      },
-                                                                    },
+                                                                    var: "user",
                                                                   },
                                                                 },
+                                                                select: "ref",
                                                               },
                                                             },
-                                                          },
+                                                          ],
                                                         },
-                                                      },
-                                                    },
-                                                    update: Expr {
-                                                      raw: {
-                                                        from: Expr {
-                                                          raw: {
-                                                            var: "user",
-                                                          },
-                                                        },
-                                                        select: "ref",
                                                       },
                                                     },
                                                   },
-                                                },
-                                              },
-                                            ],
-                                          },
-                                        },
-                                        if: Expr {
-                                          raw: {
-                                            is_nonempty: Expr {
-                                              raw: {
-                                                var: "match",
+                                                ],
                                               },
                                             },
-                                          },
-                                        },
-                                        then: Expr {
-                                          raw: {
-                                            get: Expr {
-                                              raw: {
-                                                var: "match",
-                                              },
-                                            },
+                                            select: "ref",
                                           },
                                         },
                                       },
                                     },
                                     let: [
                                       {
-                                        match: Expr {
+                                        rechargeTimestamp: Expr {
                                           raw: {
-                                            match: Expr {
+                                            default: Expr {
                                               raw: {
-                                                index: "inventories_instance_user",
+                                                now: null,
                                               },
                                             },
-                                            terms: Expr {
+                                            from: Expr {
+                                              raw: {
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
+                                              },
+                                            },
+                                            select: Expr {
+                                              raw: [
+                                                "data",
+                                                "rechargeTimestamp",
+                                              ],
+                                            },
+                                          },
+                                        },
+                                      },
+                                      {
+                                        currentPulls: Expr {
+                                          raw: {
+                                            from: Expr {
+                                              raw: {
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
+                                              },
+                                            },
+                                            select: Expr {
+                                              raw: [
+                                                "data",
+                                                "availablePulls",
+                                              ],
+                                            },
+                                          },
+                                        },
+                                      },
+                                      {
+                                        newPulls: Expr {
+                                          raw: {
+                                            max: Expr {
+                                              raw: [
+                                                0,
+                                                Expr {
+                                                  raw: {
+                                                    min: Expr {
+                                                      raw: [
+                                                        Expr {
+                                                          raw: {
+                                                            subtract: Expr {
+                                                              raw: [
+                                                                5,
+                                                                Expr {
+                                                                  raw: {
+                                                                    var: "currentPulls",
+                                                                  },
+                                                                },
+                                                              ],
+                                                            },
+                                                          },
+                                                        },
+                                                        Expr {
+                                                          raw: {
+                                                            divide: Expr {
+                                                              raw: [
+                                                                Expr {
+                                                                  raw: {
+                                                                    other: Expr {
+                                                                      raw: {
+                                                                        now: null,
+                                                                      },
+                                                                    },
+                                                                    time_diff: Expr {
+                                                                      raw: {
+                                                                        var: "rechargeTimestamp",
+                                                                      },
+                                                                    },
+                                                                    unit: "minutes",
+                                                                  },
+                                                                },
+                                                                30,
+                                                              ],
+                                                            },
+                                                          },
+                                                        },
+                                                      ],
+                                                    },
+                                                  },
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        },
+                                      },
+                                      {
+                                        rechargedPulls: Expr {
+                                          raw: {
+                                            add: Expr {
                                               raw: [
                                                 Expr {
                                                   raw: {
-                                                    from: Expr {
-                                                      raw: {
-                                                        var: "instance",
-                                                      },
-                                                    },
-                                                    select: "ref",
+                                                    var: "currentPulls",
                                                   },
                                                 },
                                                 Expr {
                                                   raw: {
-                                                    from: Expr {
-                                                      raw: {
-                                                        var: "user",
-                                                      },
-                                                    },
-                                                    select: "ref",
+                                                    var: "newPulls",
                                                   },
                                                 },
                                               ],

--- a/models/__snapshots__/replace_characters.test.ts.snap
+++ b/models/__snapshots__/replace_characters.test.ts.snap
@@ -357,48 +357,6 @@ snapshot[`model 1`] = `
                                                                         },
                                                                       },
                                                                     },
-                                                                    characters: Expr {
-                                                                      raw: {
-                                                                        append: Expr {
-                                                                          raw: {
-                                                                            from: Expr {
-                                                                              raw: {
-                                                                                var: "createdCharacter",
-                                                                              },
-                                                                            },
-                                                                            select: "ref",
-                                                                          },
-                                                                        },
-                                                                        collection: Expr {
-                                                                          raw: {
-                                                                            difference: Expr {
-                                                                              raw: [
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    from: Expr {
-                                                                                      raw: {
-                                                                                        var: "inventory",
-                                                                                      },
-                                                                                    },
-                                                                                    select: Expr {
-                                                                                      raw: [
-                                                                                        "data",
-                                                                                        "characters",
-                                                                                      ],
-                                                                                    },
-                                                                                  },
-                                                                                },
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    var: "sacrificedCharactersRefs",
-                                                                                  },
-                                                                                },
-                                                                              ],
-                                                                            },
-                                                                          },
-                                                                        },
-                                                                      },
-                                                                    },
                                                                     lastPull: Expr {
                                                                       raw: {
                                                                         now: null,
@@ -891,244 +849,6 @@ snapshot[`model 1`] = `
                                 },
                               },
                               {
-                                _inventory: Expr {
-                                  raw: {
-                                    in: Expr {
-                                      raw: {
-                                        else: Expr {
-                                          raw: {
-                                            in: Expr {
-                                              raw: {
-                                                var: "createdInventory",
-                                              },
-                                            },
-                                            let: [
-                                              {
-                                                createdInventory: Expr {
-                                                  raw: {
-                                                    create: Expr {
-                                                      raw: {
-                                                        collection: "inventory",
-                                                      },
-                                                    },
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
-                                                                instance: Expr {
-                                                                  raw: {
-                                                                    from: Expr {
-                                                                      raw: {
-                                                                        var: "instance",
-                                                                      },
-                                                                    },
-                                                                    select: "ref",
-                                                                  },
-                                                                },
-                                                                user: Expr {
-                                                                  raw: {
-                                                                    from: Expr {
-                                                                      raw: {
-                                                                        var: "user",
-                                                                      },
-                                                                    },
-                                                                    select: "ref",
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                              {
-                                                updatedInstance: Expr {
-                                                  raw: {
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                inventories: Expr {
-                                                                  raw: {
-                                                                    append: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "createdInventory",
-                                                                          },
-                                                                        },
-                                                                        select: "ref",
-                                                                      },
-                                                                    },
-                                                                    collection: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "instance",
-                                                                          },
-                                                                        },
-                                                                        select: Expr {
-                                                                          raw: [
-                                                                            "data",
-                                                                            "inventories",
-                                                                          ],
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                    update: Expr {
-                                                      raw: {
-                                                        from: Expr {
-                                                          raw: {
-                                                            var: "instance",
-                                                          },
-                                                        },
-                                                        select: "ref",
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                              {
-                                                updatedUser: Expr {
-                                                  raw: {
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                inventories: Expr {
-                                                                  raw: {
-                                                                    append: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "createdInventory",
-                                                                          },
-                                                                        },
-                                                                        select: "ref",
-                                                                      },
-                                                                    },
-                                                                    collection: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "user",
-                                                                          },
-                                                                        },
-                                                                        select: Expr {
-                                                                          raw: [
-                                                                            "data",
-                                                                            "inventories",
-                                                                          ],
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                    update: Expr {
-                                                      raw: {
-                                                        from: Expr {
-                                                          raw: {
-                                                            var: "user",
-                                                          },
-                                                        },
-                                                        select: "ref",
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                            ],
-                                          },
-                                        },
-                                        if: Expr {
-                                          raw: {
-                                            is_nonempty: Expr {
-                                              raw: {
-                                                var: "match",
-                                              },
-                                            },
-                                          },
-                                        },
-                                        then: Expr {
-                                          raw: {
-                                            get: Expr {
-                                              raw: {
-                                                var: "match",
-                                              },
-                                            },
-                                          },
-                                        },
-                                      },
-                                    },
-                                    let: [
-                                      {
-                                        match: Expr {
-                                          raw: {
-                                            match: Expr {
-                                              raw: {
-                                                index: "inventories_instance_user",
-                                              },
-                                            },
-                                            terms: Expr {
-                                              raw: [
-                                                Expr {
-                                                  raw: {
-                                                    from: Expr {
-                                                      raw: {
-                                                        var: "instance",
-                                                      },
-                                                    },
-                                                    select: "ref",
-                                                  },
-                                                },
-                                                Expr {
-                                                  raw: {
-                                                    from: Expr {
-                                                      raw: {
-                                                        var: "user",
-                                                      },
-                                                    },
-                                                    select: "ref",
-                                                  },
-                                                },
-                                              ],
-                                            },
-                                          },
-                                        },
-                                      },
-                                    ],
-                                  },
-                                },
-                              },
-                              {
                                 inventory: Expr {
                                   raw: {
                                     in: Expr {
@@ -1206,7 +926,234 @@ snapshot[`model 1`] = `
                                           raw: {
                                             from: Expr {
                                               raw: {
-                                                var: "_inventory",
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
                                               },
                                             },
                                             select: "ref",
@@ -1225,7 +1172,234 @@ snapshot[`model 1`] = `
                                             },
                                             from: Expr {
                                               raw: {
-                                                var: "_inventory",
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
                                               },
                                             },
                                             select: Expr {
@@ -1242,7 +1416,234 @@ snapshot[`model 1`] = `
                                           raw: {
                                             from: Expr {
                                               raw: {
-                                                var: "_inventory",
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
                                               },
                                             },
                                             select: Expr {
@@ -1720,48 +2121,6 @@ snapshot[`model 1`] = `
                                                                         },
                                                                       },
                                                                     },
-                                                                    characters: Expr {
-                                                                      raw: {
-                                                                        append: Expr {
-                                                                          raw: {
-                                                                            from: Expr {
-                                                                              raw: {
-                                                                                var: "createdCharacter",
-                                                                              },
-                                                                            },
-                                                                            select: "ref",
-                                                                          },
-                                                                        },
-                                                                        collection: Expr {
-                                                                          raw: {
-                                                                            difference: Expr {
-                                                                              raw: [
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    from: Expr {
-                                                                                      raw: {
-                                                                                        var: "inventory",
-                                                                                      },
-                                                                                    },
-                                                                                    select: Expr {
-                                                                                      raw: [
-                                                                                        "data",
-                                                                                        "characters",
-                                                                                      ],
-                                                                                    },
-                                                                                  },
-                                                                                },
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    var: "sacrificedCharactersRefs",
-                                                                                  },
-                                                                                },
-                                                                              ],
-                                                                            },
-                                                                          },
-                                                                        },
-                                                                      },
-                                                                    },
                                                                     lastPull: Expr {
                                                                       raw: {
                                                                         now: null,
@@ -2254,244 +2613,6 @@ snapshot[`model 1`] = `
                                 },
                               },
                               {
-                                _inventory: Expr {
-                                  raw: {
-                                    in: Expr {
-                                      raw: {
-                                        else: Expr {
-                                          raw: {
-                                            in: Expr {
-                                              raw: {
-                                                var: "createdInventory",
-                                              },
-                                            },
-                                            let: [
-                                              {
-                                                createdInventory: Expr {
-                                                  raw: {
-                                                    create: Expr {
-                                                      raw: {
-                                                        collection: "inventory",
-                                                      },
-                                                    },
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
-                                                                instance: Expr {
-                                                                  raw: {
-                                                                    from: Expr {
-                                                                      raw: {
-                                                                        var: "instance",
-                                                                      },
-                                                                    },
-                                                                    select: "ref",
-                                                                  },
-                                                                },
-                                                                user: Expr {
-                                                                  raw: {
-                                                                    from: Expr {
-                                                                      raw: {
-                                                                        var: "user",
-                                                                      },
-                                                                    },
-                                                                    select: "ref",
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                              {
-                                                updatedInstance: Expr {
-                                                  raw: {
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                inventories: Expr {
-                                                                  raw: {
-                                                                    append: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "createdInventory",
-                                                                          },
-                                                                        },
-                                                                        select: "ref",
-                                                                      },
-                                                                    },
-                                                                    collection: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "instance",
-                                                                          },
-                                                                        },
-                                                                        select: Expr {
-                                                                          raw: [
-                                                                            "data",
-                                                                            "inventories",
-                                                                          ],
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                    update: Expr {
-                                                      raw: {
-                                                        from: Expr {
-                                                          raw: {
-                                                            var: "instance",
-                                                          },
-                                                        },
-                                                        select: "ref",
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                              {
-                                                updatedUser: Expr {
-                                                  raw: {
-                                                    params: Expr {
-                                                      raw: {
-                                                        object: {
-                                                          data: Expr {
-                                                            raw: {
-                                                              object: {
-                                                                inventories: Expr {
-                                                                  raw: {
-                                                                    append: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "createdInventory",
-                                                                          },
-                                                                        },
-                                                                        select: "ref",
-                                                                      },
-                                                                    },
-                                                                    collection: Expr {
-                                                                      raw: {
-                                                                        from: Expr {
-                                                                          raw: {
-                                                                            var: "user",
-                                                                          },
-                                                                        },
-                                                                        select: Expr {
-                                                                          raw: [
-                                                                            "data",
-                                                                            "inventories",
-                                                                          ],
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                    update: Expr {
-                                                      raw: {
-                                                        from: Expr {
-                                                          raw: {
-                                                            var: "user",
-                                                          },
-                                                        },
-                                                        select: "ref",
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              },
-                                            ],
-                                          },
-                                        },
-                                        if: Expr {
-                                          raw: {
-                                            is_nonempty: Expr {
-                                              raw: {
-                                                var: "match",
-                                              },
-                                            },
-                                          },
-                                        },
-                                        then: Expr {
-                                          raw: {
-                                            get: Expr {
-                                              raw: {
-                                                var: "match",
-                                              },
-                                            },
-                                          },
-                                        },
-                                      },
-                                    },
-                                    let: [
-                                      {
-                                        match: Expr {
-                                          raw: {
-                                            match: Expr {
-                                              raw: {
-                                                index: "inventories_instance_user",
-                                              },
-                                            },
-                                            terms: Expr {
-                                              raw: [
-                                                Expr {
-                                                  raw: {
-                                                    from: Expr {
-                                                      raw: {
-                                                        var: "instance",
-                                                      },
-                                                    },
-                                                    select: "ref",
-                                                  },
-                                                },
-                                                Expr {
-                                                  raw: {
-                                                    from: Expr {
-                                                      raw: {
-                                                        var: "user",
-                                                      },
-                                                    },
-                                                    select: "ref",
-                                                  },
-                                                },
-                                              ],
-                                            },
-                                          },
-                                        },
-                                      },
-                                    ],
-                                  },
-                                },
-                              },
-                              {
                                 inventory: Expr {
                                   raw: {
                                     in: Expr {
@@ -2569,7 +2690,234 @@ snapshot[`model 1`] = `
                                           raw: {
                                             from: Expr {
                                               raw: {
-                                                var: "_inventory",
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
                                               },
                                             },
                                             select: "ref",
@@ -2588,7 +2936,234 @@ snapshot[`model 1`] = `
                                             },
                                             from: Expr {
                                               raw: {
-                                                var: "_inventory",
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
                                               },
                                             },
                                             select: Expr {
@@ -2605,7 +3180,234 @@ snapshot[`model 1`] = `
                                           raw: {
                                             from: Expr {
                                               raw: {
-                                                var: "_inventory",
+                                                in: Expr {
+                                                  raw: {
+                                                    else: Expr {
+                                                      raw: {
+                                                        in: Expr {
+                                                          raw: {
+                                                            var: "createdInventory",
+                                                          },
+                                                        },
+                                                        let: [
+                                                          {
+                                                            createdInventory: Expr {
+                                                              raw: {
+                                                                create: Expr {
+                                                                  raw: {
+                                                                    collection: "inventory",
+                                                                  },
+                                                                },
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            availablePulls: 5,
+                                                                            instance: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "instance",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                            user: Expr {
+                                                                              raw: {
+                                                                                from: Expr {
+                                                                                  raw: {
+                                                                                    var: "user",
+                                                                                  },
+                                                                                },
+                                                                                select: "ref",
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedInstance: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "instance",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "instance",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                          {
+                                                            updatedUser: Expr {
+                                                              raw: {
+                                                                params: Expr {
+                                                                  raw: {
+                                                                    object: {
+                                                                      data: Expr {
+                                                                        raw: {
+                                                                          object: {
+                                                                            inventories: Expr {
+                                                                              raw: {
+                                                                                append: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "createdInventory",
+                                                                                      },
+                                                                                    },
+                                                                                    select: "ref",
+                                                                                  },
+                                                                                },
+                                                                                collection: Expr {
+                                                                                  raw: {
+                                                                                    from: Expr {
+                                                                                      raw: {
+                                                                                        var: "user",
+                                                                                      },
+                                                                                    },
+                                                                                    select: Expr {
+                                                                                      raw: [
+                                                                                        "data",
+                                                                                        "inventories",
+                                                                                      ],
+                                                                                    },
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      },
+                                                                    },
+                                                                  },
+                                                                },
+                                                                update: Expr {
+                                                                  raw: {
+                                                                    from: Expr {
+                                                                      raw: {
+                                                                        var: "user",
+                                                                      },
+                                                                    },
+                                                                    select: "ref",
+                                                                  },
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    if: Expr {
+                                                      raw: {
+                                                        is_nonempty: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    then: Expr {
+                                                      raw: {
+                                                        get: Expr {
+                                                          raw: {
+                                                            var: "match",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                },
+                                                let: [
+                                                  {
+                                                    match: Expr {
+                                                      raw: {
+                                                        match: Expr {
+                                                          raw: {
+                                                            index: "inventories_instance_user",
+                                                          },
+                                                        },
+                                                        terms: Expr {
+                                                          raw: [
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "instance",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                            Expr {
+                                                              raw: {
+                                                                from: Expr {
+                                                                  raw: {
+                                                                    var: "user",
+                                                                  },
+                                                                },
+                                                                select: "ref",
+                                                              },
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
                                               },
                                             },
                                             select: Expr {

--- a/models/__snapshots__/set_character_to_party.test.ts.snap
+++ b/models/__snapshots__/set_character_to_party.test.ts.snap
@@ -1255,10 +1255,6 @@ snapshot[`model 1`] = `
                                                             raw: {
                                                               object: {
                                                                 availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
                                                                 instance: Expr {
                                                                   raw: {
                                                                     from: Expr {
@@ -2746,10 +2742,6 @@ snapshot[`model 1`] = `
                                                             raw: {
                                                               object: {
                                                                 availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
                                                                 instance: Expr {
                                                                   raw: {
                                                                     from: Expr {
@@ -4027,10 +4019,6 @@ snapshot[`model 2`] = `
                                                             raw: {
                                                               object: {
                                                                 availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
                                                                 instance: Expr {
                                                                   raw: {
                                                                     from: Expr {
@@ -5303,10 +5291,6 @@ snapshot[`model 2`] = `
                                                             raw: {
                                                               object: {
                                                                 availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
                                                                 instance: Expr {
                                                                   raw: {
                                                                     from: Expr {
@@ -6191,10 +6175,6 @@ snapshot[`model 3`] = `
                                                             raw: {
                                                               object: {
                                                                 availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
                                                                 instance: Expr {
                                                                   raw: {
                                                                     from: Expr {
@@ -7073,10 +7053,6 @@ snapshot[`model 3`] = `
                                                             raw: {
                                                               object: {
                                                                 availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
                                                                 instance: Expr {
                                                                   raw: {
                                                                     from: Expr {

--- a/models/__snapshots__/steal_character.test.ts.snap
+++ b/models/__snapshots__/steal_character.test.ts.snap
@@ -51,118 +51,6 @@ snapshot[`model 1`] = `
                                                 },
                                                 let: [
                                                   {
-                                                    updatedInventory: Expr {
-                                                      raw: {
-                                                        params: Expr {
-                                                          raw: {
-                                                            object: {
-                                                              data: Expr {
-                                                                raw: {
-                                                                  object: {
-                                                                    characters: Expr {
-                                                                      raw: {
-                                                                        append: Expr {
-                                                                          raw: {
-                                                                            var: "characterRef",
-                                                                          },
-                                                                        },
-                                                                        collection: Expr {
-                                                                          raw: {
-                                                                            from: Expr {
-                                                                              raw: {
-                                                                                var: "inventory",
-                                                                              },
-                                                                            },
-                                                                            select: Expr {
-                                                                              raw: [
-                                                                                "data",
-                                                                                "characters",
-                                                                              ],
-                                                                            },
-                                                                          },
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                        update: Expr {
-                                                          raw: {
-                                                            from: Expr {
-                                                              raw: {
-                                                                var: "inventory",
-                                                              },
-                                                            },
-                                                            select: "ref",
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                  },
-                                                  {
-                                                    updatedTargetInventory: Expr {
-                                                      raw: {
-                                                        params: Expr {
-                                                          raw: {
-                                                            object: {
-                                                              data: Expr {
-                                                                raw: {
-                                                                  object: {
-                                                                    characters: Expr {
-                                                                      raw: {
-                                                                        difference: Expr {
-                                                                          raw: [
-                                                                            Expr {
-                                                                              raw: {
-                                                                                from: Expr {
-                                                                                  raw: {
-                                                                                    var: "inventory",
-                                                                                  },
-                                                                                },
-                                                                                select: Expr {
-                                                                                  raw: [
-                                                                                    "data",
-                                                                                    "characters",
-                                                                                  ],
-                                                                                },
-                                                                              },
-                                                                            },
-                                                                            Expr {
-                                                                              raw: [
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    var: "characterRef",
-                                                                                  },
-                                                                                },
-                                                                              ],
-                                                                            },
-                                                                          ],
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                        update: Expr {
-                                                          raw: {
-                                                            from: Expr {
-                                                              raw: {
-                                                                var: "targetInventory",
-                                                              },
-                                                            },
-                                                            select: "ref",
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                  },
-                                                  {
                                                     updatedCharacter: Expr {
                                                       raw: {
                                                         params: Expr {
@@ -448,10 +336,6 @@ snapshot[`model 1`] = `
                                                                         raw: {
                                                                           object: {
                                                                             availablePulls: 5,
-                                                                            characters: Expr {
-                                                                              raw: [
-                                                                              ],
-                                                                            },
                                                                             instance: Expr {
                                                                               raw: {
                                                                                 from: Expr {
@@ -1043,10 +927,6 @@ snapshot[`model 1`] = `
                                                             raw: {
                                                               object: {
                                                                 availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
                                                                 instance: Expr {
                                                                   raw: {
                                                                     from: Expr {
@@ -1329,118 +1209,6 @@ snapshot[`model 1`] = `
                                                 },
                                                 let: [
                                                   {
-                                                    updatedInventory: Expr {
-                                                      raw: {
-                                                        params: Expr {
-                                                          raw: {
-                                                            object: {
-                                                              data: Expr {
-                                                                raw: {
-                                                                  object: {
-                                                                    characters: Expr {
-                                                                      raw: {
-                                                                        append: Expr {
-                                                                          raw: {
-                                                                            var: "characterRef",
-                                                                          },
-                                                                        },
-                                                                        collection: Expr {
-                                                                          raw: {
-                                                                            from: Expr {
-                                                                              raw: {
-                                                                                var: "inventory",
-                                                                              },
-                                                                            },
-                                                                            select: Expr {
-                                                                              raw: [
-                                                                                "data",
-                                                                                "characters",
-                                                                              ],
-                                                                            },
-                                                                          },
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                        update: Expr {
-                                                          raw: {
-                                                            from: Expr {
-                                                              raw: {
-                                                                var: "inventory",
-                                                              },
-                                                            },
-                                                            select: "ref",
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                  },
-                                                  {
-                                                    updatedTargetInventory: Expr {
-                                                      raw: {
-                                                        params: Expr {
-                                                          raw: {
-                                                            object: {
-                                                              data: Expr {
-                                                                raw: {
-                                                                  object: {
-                                                                    characters: Expr {
-                                                                      raw: {
-                                                                        difference: Expr {
-                                                                          raw: [
-                                                                            Expr {
-                                                                              raw: {
-                                                                                from: Expr {
-                                                                                  raw: {
-                                                                                    var: "inventory",
-                                                                                  },
-                                                                                },
-                                                                                select: Expr {
-                                                                                  raw: [
-                                                                                    "data",
-                                                                                    "characters",
-                                                                                  ],
-                                                                                },
-                                                                              },
-                                                                            },
-                                                                            Expr {
-                                                                              raw: [
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    var: "characterRef",
-                                                                                  },
-                                                                                },
-                                                                              ],
-                                                                            },
-                                                                          ],
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                        update: Expr {
-                                                          raw: {
-                                                            from: Expr {
-                                                              raw: {
-                                                                var: "targetInventory",
-                                                              },
-                                                            },
-                                                            select: "ref",
-                                                          },
-                                                        },
-                                                      },
-                                                    },
-                                                  },
-                                                  {
                                                     updatedCharacter: Expr {
                                                       raw: {
                                                         params: Expr {
@@ -1726,10 +1494,6 @@ snapshot[`model 1`] = `
                                                                         raw: {
                                                                           object: {
                                                                             availablePulls: 5,
-                                                                            characters: Expr {
-                                                                              raw: [
-                                                                              ],
-                                                                            },
                                                                             instance: Expr {
                                                                               raw: {
                                                                                 from: Expr {
@@ -2321,10 +2085,6 @@ snapshot[`model 1`] = `
                                                             raw: {
                                                               object: {
                                                                 availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
                                                                 instance: Expr {
                                                                   raw: {
                                                                     from: Expr {

--- a/models/__snapshots__/trade_characters.test.ts.snap
+++ b/models/__snapshots__/trade_characters.test.ts.snap
@@ -134,118 +134,6 @@ snapshot[`model 1`] = `
                                                     },
                                                     let: [
                                                       {
-                                                        updatedInventory: Expr {
-                                                          raw: {
-                                                            params: Expr {
-                                                              raw: {
-                                                                object: {
-                                                                  data: Expr {
-                                                                    raw: {
-                                                                      object: {
-                                                                        characters: Expr {
-                                                                          raw: {
-                                                                            difference: Expr {
-                                                                              raw: [
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    from: Expr {
-                                                                                      raw: {
-                                                                                        var: "inventory",
-                                                                                      },
-                                                                                    },
-                                                                                    select: Expr {
-                                                                                      raw: [
-                                                                                        "data",
-                                                                                        "characters",
-                                                                                      ],
-                                                                                    },
-                                                                                  },
-                                                                                },
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    var: "giveCharactersRefs",
-                                                                                  },
-                                                                                },
-                                                                              ],
-                                                                            },
-                                                                          },
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                            update: Expr {
-                                                              raw: {
-                                                                from: Expr {
-                                                                  raw: {
-                                                                    var: "inventory",
-                                                                  },
-                                                                },
-                                                                select: "ref",
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                      {
-                                                        updatedTargetInventory: Expr {
-                                                          raw: {
-                                                            params: Expr {
-                                                              raw: {
-                                                                object: {
-                                                                  data: Expr {
-                                                                    raw: {
-                                                                      object: {
-                                                                        characters: Expr {
-                                                                          raw: {
-                                                                            union: Expr {
-                                                                              raw: [
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    from: Expr {
-                                                                                      raw: {
-                                                                                        var: "targetInventory",
-                                                                                      },
-                                                                                    },
-                                                                                    select: Expr {
-                                                                                      raw: [
-                                                                                        "data",
-                                                                                        "characters",
-                                                                                      ],
-                                                                                    },
-                                                                                  },
-                                                                                },
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    var: "giveCharactersRefs",
-                                                                                  },
-                                                                                },
-                                                                              ],
-                                                                            },
-                                                                          },
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                            update: Expr {
-                                                              raw: {
-                                                                from: Expr {
-                                                                  raw: {
-                                                                    var: "targetInventory",
-                                                                  },
-                                                                },
-                                                                select: "ref",
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                      {
                                                         updatedCharacters: Expr {
                                                           raw: {
                                                             collection: Expr {
@@ -1015,10 +903,6 @@ snapshot[`model 1`] = `
                                                             raw: {
                                                               object: {
                                                                 availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
                                                                 instance: Expr {
                                                                   raw: {
                                                                     from: Expr {
@@ -1253,10 +1137,6 @@ snapshot[`model 1`] = `
                                                             raw: {
                                                               object: {
                                                                 availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
                                                                 instance: Expr {
                                                                   raw: {
                                                                     from: Expr {
@@ -1623,118 +1503,6 @@ snapshot[`model 1`] = `
                                                     },
                                                     let: [
                                                       {
-                                                        updatedInventory: Expr {
-                                                          raw: {
-                                                            params: Expr {
-                                                              raw: {
-                                                                object: {
-                                                                  data: Expr {
-                                                                    raw: {
-                                                                      object: {
-                                                                        characters: Expr {
-                                                                          raw: {
-                                                                            difference: Expr {
-                                                                              raw: [
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    from: Expr {
-                                                                                      raw: {
-                                                                                        var: "inventory",
-                                                                                      },
-                                                                                    },
-                                                                                    select: Expr {
-                                                                                      raw: [
-                                                                                        "data",
-                                                                                        "characters",
-                                                                                      ],
-                                                                                    },
-                                                                                  },
-                                                                                },
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    var: "giveCharactersRefs",
-                                                                                  },
-                                                                                },
-                                                                              ],
-                                                                            },
-                                                                          },
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                            update: Expr {
-                                                              raw: {
-                                                                from: Expr {
-                                                                  raw: {
-                                                                    var: "inventory",
-                                                                  },
-                                                                },
-                                                                select: "ref",
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                      {
-                                                        updatedTargetInventory: Expr {
-                                                          raw: {
-                                                            params: Expr {
-                                                              raw: {
-                                                                object: {
-                                                                  data: Expr {
-                                                                    raw: {
-                                                                      object: {
-                                                                        characters: Expr {
-                                                                          raw: {
-                                                                            union: Expr {
-                                                                              raw: [
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    from: Expr {
-                                                                                      raw: {
-                                                                                        var: "targetInventory",
-                                                                                      },
-                                                                                    },
-                                                                                    select: Expr {
-                                                                                      raw: [
-                                                                                        "data",
-                                                                                        "characters",
-                                                                                      ],
-                                                                                    },
-                                                                                  },
-                                                                                },
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    var: "giveCharactersRefs",
-                                                                                  },
-                                                                                },
-                                                                              ],
-                                                                            },
-                                                                          },
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                            update: Expr {
-                                                              raw: {
-                                                                from: Expr {
-                                                                  raw: {
-                                                                    var: "targetInventory",
-                                                                  },
-                                                                },
-                                                                select: "ref",
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                      {
                                                         updatedCharacters: Expr {
                                                           raw: {
                                                             collection: Expr {
@@ -2504,10 +2272,6 @@ snapshot[`model 1`] = `
                                                             raw: {
                                                               object: {
                                                                 availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
                                                                 instance: Expr {
                                                                   raw: {
                                                                     from: Expr {
@@ -2742,10 +2506,6 @@ snapshot[`model 1`] = `
                                                             raw: {
                                                               object: {
                                                                 availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
                                                                 instance: Expr {
                                                                   raw: {
                                                                     from: Expr {
@@ -3215,144 +2975,6 @@ snapshot[`model 2`] = `
                                                     },
                                                     let: [
                                                       {
-                                                        updatedInventory: Expr {
-                                                          raw: {
-                                                            params: Expr {
-                                                              raw: {
-                                                                object: {
-                                                                  data: Expr {
-                                                                    raw: {
-                                                                      object: {
-                                                                        characters: Expr {
-                                                                          raw: {
-                                                                            union: Expr {
-                                                                              raw: [
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    var: "takeCharactersRefs",
-                                                                                  },
-                                                                                },
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    difference: Expr {
-                                                                                      raw: [
-                                                                                        Expr {
-                                                                                          raw: {
-                                                                                            from: Expr {
-                                                                                              raw: {
-                                                                                                var: "inventory",
-                                                                                              },
-                                                                                            },
-                                                                                            select: Expr {
-                                                                                              raw: [
-                                                                                                "data",
-                                                                                                "characters",
-                                                                                              ],
-                                                                                            },
-                                                                                          },
-                                                                                        },
-                                                                                        Expr {
-                                                                                          raw: {
-                                                                                            var: "giveCharactersRefs",
-                                                                                          },
-                                                                                        },
-                                                                                      ],
-                                                                                    },
-                                                                                  },
-                                                                                },
-                                                                              ],
-                                                                            },
-                                                                          },
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                            update: Expr {
-                                                              raw: {
-                                                                from: Expr {
-                                                                  raw: {
-                                                                    var: "inventory",
-                                                                  },
-                                                                },
-                                                                select: "ref",
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                      {
-                                                        updatedTargetInventory: Expr {
-                                                          raw: {
-                                                            params: Expr {
-                                                              raw: {
-                                                                object: {
-                                                                  data: Expr {
-                                                                    raw: {
-                                                                      object: {
-                                                                        characters: Expr {
-                                                                          raw: {
-                                                                            union: Expr {
-                                                                              raw: [
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    var: "giveCharactersRefs",
-                                                                                  },
-                                                                                },
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    difference: Expr {
-                                                                                      raw: [
-                                                                                        Expr {
-                                                                                          raw: {
-                                                                                            from: Expr {
-                                                                                              raw: {
-                                                                                                var: "inventory",
-                                                                                              },
-                                                                                            },
-                                                                                            select: Expr {
-                                                                                              raw: [
-                                                                                                "data",
-                                                                                                "characters",
-                                                                                              ],
-                                                                                            },
-                                                                                          },
-                                                                                        },
-                                                                                        Expr {
-                                                                                          raw: {
-                                                                                            var: "takeCharactersRefs",
-                                                                                          },
-                                                                                        },
-                                                                                      ],
-                                                                                    },
-                                                                                  },
-                                                                                },
-                                                                              ],
-                                                                            },
-                                                                          },
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                            update: Expr {
-                                                              raw: {
-                                                                from: Expr {
-                                                                  raw: {
-                                                                    var: "targetInventory",
-                                                                  },
-                                                                },
-                                                                select: "ref",
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                      {
                                                         updatedCharacters: Expr {
                                                           raw: {
                                                             collection: Expr {
@@ -4439,10 +4061,6 @@ snapshot[`model 2`] = `
                                                             raw: {
                                                               object: {
                                                                 availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
                                                                 instance: Expr {
                                                                   raw: {
                                                                     from: Expr {
@@ -4677,10 +4295,6 @@ snapshot[`model 2`] = `
                                                             raw: {
                                                               object: {
                                                                 availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
                                                                 instance: Expr {
                                                                   raw: {
                                                                     from: Expr {
@@ -5146,144 +4760,6 @@ snapshot[`model 2`] = `
                                                     },
                                                     let: [
                                                       {
-                                                        updatedInventory: Expr {
-                                                          raw: {
-                                                            params: Expr {
-                                                              raw: {
-                                                                object: {
-                                                                  data: Expr {
-                                                                    raw: {
-                                                                      object: {
-                                                                        characters: Expr {
-                                                                          raw: {
-                                                                            union: Expr {
-                                                                              raw: [
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    var: "takeCharactersRefs",
-                                                                                  },
-                                                                                },
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    difference: Expr {
-                                                                                      raw: [
-                                                                                        Expr {
-                                                                                          raw: {
-                                                                                            from: Expr {
-                                                                                              raw: {
-                                                                                                var: "inventory",
-                                                                                              },
-                                                                                            },
-                                                                                            select: Expr {
-                                                                                              raw: [
-                                                                                                "data",
-                                                                                                "characters",
-                                                                                              ],
-                                                                                            },
-                                                                                          },
-                                                                                        },
-                                                                                        Expr {
-                                                                                          raw: {
-                                                                                            var: "giveCharactersRefs",
-                                                                                          },
-                                                                                        },
-                                                                                      ],
-                                                                                    },
-                                                                                  },
-                                                                                },
-                                                                              ],
-                                                                            },
-                                                                          },
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                            update: Expr {
-                                                              raw: {
-                                                                from: Expr {
-                                                                  raw: {
-                                                                    var: "inventory",
-                                                                  },
-                                                                },
-                                                                select: "ref",
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                      {
-                                                        updatedTargetInventory: Expr {
-                                                          raw: {
-                                                            params: Expr {
-                                                              raw: {
-                                                                object: {
-                                                                  data: Expr {
-                                                                    raw: {
-                                                                      object: {
-                                                                        characters: Expr {
-                                                                          raw: {
-                                                                            union: Expr {
-                                                                              raw: [
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    var: "giveCharactersRefs",
-                                                                                  },
-                                                                                },
-                                                                                Expr {
-                                                                                  raw: {
-                                                                                    difference: Expr {
-                                                                                      raw: [
-                                                                                        Expr {
-                                                                                          raw: {
-                                                                                            from: Expr {
-                                                                                              raw: {
-                                                                                                var: "inventory",
-                                                                                              },
-                                                                                            },
-                                                                                            select: Expr {
-                                                                                              raw: [
-                                                                                                "data",
-                                                                                                "characters",
-                                                                                              ],
-                                                                                            },
-                                                                                          },
-                                                                                        },
-                                                                                        Expr {
-                                                                                          raw: {
-                                                                                            var: "takeCharactersRefs",
-                                                                                          },
-                                                                                        },
-                                                                                      ],
-                                                                                    },
-                                                                                  },
-                                                                                },
-                                                                              ],
-                                                                            },
-                                                                          },
-                                                                        },
-                                                                      },
-                                                                    },
-                                                                  },
-                                                                },
-                                                              },
-                                                            },
-                                                            update: Expr {
-                                                              raw: {
-                                                                from: Expr {
-                                                                  raw: {
-                                                                    var: "targetInventory",
-                                                                  },
-                                                                },
-                                                                select: "ref",
-                                                              },
-                                                            },
-                                                          },
-                                                        },
-                                                      },
-                                                      {
                                                         updatedCharacters: Expr {
                                                           raw: {
                                                             collection: Expr {
@@ -6370,10 +5846,6 @@ snapshot[`model 2`] = `
                                                             raw: {
                                                               object: {
                                                                 availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
                                                                 instance: Expr {
                                                                   raw: {
                                                                     from: Expr {
@@ -6608,10 +6080,6 @@ snapshot[`model 2`] = `
                                                             raw: {
                                                               object: {
                                                                 availablePulls: 5,
-                                                                characters: Expr {
-                                                                  raw: [
-                                                                  ],
-                                                                },
                                                                 instance: Expr {
                                                                   raw: {
                                                                     from: Expr {

--- a/models/add_character_to_inventory.ts
+++ b/models/add_character_to_inventory.ts
@@ -111,10 +111,6 @@ export function addCharacter(
                   fql.Select(['data', 'availablePulls'], inventory),
                   1,
                 ),
-                characters: fql.Append(
-                  fql.Ref(fql.Var('createdCharacter')),
-                  fql.Select(['data', 'characters'], inventory, []),
-                ),
               }),
             },
             ({ updatedInventory, createdCharacter }) => ({
@@ -177,12 +173,11 @@ export default function (client: Client): {
               user: getUser(userId),
               guild: getGuild(guildId),
               instance: getInstance(fql.Var('guild')),
-              _inventory: getInventory({
-                user: fql.Var('user'),
-                instance: fql.Var('instance'),
-              }),
               inventory: rechargePulls({
-                inventory: fql.Var('_inventory'),
+                inventory: getInventory({
+                  user: fql.Var('user'),
+                  instance: fql.Var('instance'),
+                }),
               }),
             },
             ({ inventory, instance, user }) =>

--- a/models/add_vote_to_user.ts
+++ b/models/add_vote_to_user.ts
@@ -161,12 +161,11 @@ export default function (client: Client): {
               user: getUser(userId),
               guild: getGuild(guildId),
               instance: getInstance(fql.Var('guild')),
-              _inventory: getInventory({
-                user: fql.Var('user'),
-                instance: fql.Var('instance'),
-              }),
               inventory: rechargePulls({
-                inventory: fql.Var('_inventory'),
+                inventory: getInventory({
+                  user: fql.Var('user'),
+                  instance: fql.Var('instance'),
+                }),
               }),
             },
             ({ user, inventory }) => addPulls({ user, inventory, votes }),

--- a/models/fql.ts
+++ b/models/fql.ts
@@ -73,16 +73,8 @@ function Append<T extends ExprArg>(ref: T, items: T[]): T[] {
   return _fql.Append(ref, items) as unknown as T[];
 }
 
-function AppendAll<T extends ExprArg>(refs: T[], items: T[]): T[] {
-  return _fql.Union(items, refs) as unknown as T[];
-}
-
 function Remove<T extends ExprArg>(ref: T, items: T[]): T[] {
   return _fql.Difference(items, [ref]) as unknown as T[];
-}
-
-function RemoveAll<T extends ExprArg>(refs: T[], items: T[]): T[] {
-  return _fql.Difference(items, refs) as unknown as T[];
 }
 
 function Delete(ref: RefExpr): Expr {
@@ -327,7 +319,6 @@ export const fql = {
   And,
   Any,
   Append,
-  AppendAll,
   Concat,
   Create,
   Delete,
@@ -358,7 +349,6 @@ export const fql = {
   Paginate,
   Ref,
   Remove,
-  RemoveAll,
   Resolver,
   Reverse,
   Select,

--- a/models/get_user_inventory.test.ts
+++ b/models/get_user_inventory.test.ts
@@ -20,13 +20,14 @@ Deno.test('model', async (test) => {
   Model(client as any).indexers?.forEach((q) => q());
   Model(client as any).resolvers?.forEach((q) => q());
 
-  assertSpyCalls(client.query, 5);
+  assertSpyCalls(client.query, 6);
 
   await assertSnapshot(test, client.query.calls[0].args);
   await assertSnapshot(test, client.query.calls[1].args);
   await assertSnapshot(test, client.query.calls[2].args);
   await assertSnapshot(test, client.query.calls[3].args);
   await assertSnapshot(test, client.query.calls[4].args);
+  await assertSnapshot(test, client.query.calls[5].args);
 });
 
 Deno.test('variables', () => {

--- a/models/replace_characters.ts
+++ b/models/replace_characters.ts
@@ -97,13 +97,6 @@ export function replaceCharacters(
                   fql.Select(['data', 'availablePulls'], inventory),
                   1,
                 ),
-                characters: fql.Append(
-                  fql.Ref(fql.Var('createdCharacter')),
-                  fql.RemoveAll(
-                    fql.Var<RefExpr[]>('sacrificedCharactersRefs'),
-                    fql.Select(['data', 'characters'], inventory),
-                  ),
-                ),
               }),
             },
             ({ updatedInventory, createdCharacter }) => ({
@@ -158,12 +151,11 @@ export default function (client: Client): {
               user: getUser(userId),
               guild: getGuild(guildId),
               instance: getInstance(fql.Var('guild')),
-              _inventory: getInventory({
-                user: fql.Var('user'),
-                instance: fql.Var('instance'),
-              }),
               inventory: rechargePulls({
-                inventory: fql.Var('_inventory'),
+                inventory: getInventory({
+                  user: fql.Var('user'),
+                  instance: fql.Var('instance'),
+                }),
               }),
             },
             ({ inventory, instance, user }) =>

--- a/models/steal_character.ts
+++ b/models/steal_character.ts
@@ -14,7 +14,6 @@ import {
   getInstance,
   getInventory,
   getUser,
-  Inventory,
 } from './get_user_inventory.ts';
 
 import { Character } from './add_character_to_inventory.ts';
@@ -97,24 +96,6 @@ export function stealCharacter(
             error: 'CHARACTER_IN_PARTY',
           },
           fql.Let({
-            updatedInventory: fql.Update<Inventory>(
-              fql.Ref(inventory),
-              {
-                characters: fql.Append(
-                  characterRef,
-                  fql.Select(['data', 'characters'], inventory),
-                ),
-              },
-            ),
-            updatedTargetInventory: fql.Update<Inventory>(
-              fql.Ref(targetInventory),
-              {
-                characters: fql.Remove(
-                  characterRef,
-                  fql.Select(['data', 'characters'], inventory),
-                ),
-              },
-            ),
             updatedCharacter: fql.Update<Character>(
               characterRef,
               {

--- a/models/trade_characters.ts
+++ b/models/trade_characters.ts
@@ -13,7 +13,6 @@ import {
   getInstance,
   getInventory,
   getUser,
-  Inventory,
 } from './get_user_inventory.ts';
 
 import { Character } from './add_character_to_inventory.ts';
@@ -108,21 +107,6 @@ export function giveCharacters(
               error: 'CHARACTER_IN_PARTY',
             },
             fql.Let({
-              updatedInventory: fql.Update<Inventory>(fql.Ref(inventory), {
-                characters: fql.RemoveAll(
-                  giveCharactersRefs,
-                  fql.Select(['data', 'characters'], inventory),
-                ),
-              }),
-              updatedTargetInventory: fql.Update<Inventory>(
-                fql.Ref(targetInventory),
-                {
-                  characters: fql.AppendAll(
-                    giveCharactersRefs,
-                    fql.Select(['data', 'characters'], targetInventory),
-                  ),
-                },
-              ),
               updatedCharacters: fql.Foreach(
                 giveCharactersRefs,
                 (characterRef) =>
@@ -308,27 +292,6 @@ export function tradeCharacters(
               error: 'CHARACTER_IN_PARTY',
             },
             fql.Let({
-              updatedInventory: fql.Update<Inventory>(fql.Ref(inventory), {
-                characters: fql.AppendAll(
-                  fql.RemoveAll(
-                    giveCharactersRefs,
-                    fql.Select(['data', 'characters'], inventory),
-                  ),
-                  takeCharactersRefs,
-                ),
-              }),
-              updatedTargetInventory: fql.Update<Inventory>(
-                fql.Ref(targetInventory),
-                {
-                  characters: fql.AppendAll(
-                    fql.RemoveAll(
-                      takeCharactersRefs,
-                      fql.Select(['data', 'characters'], inventory),
-                    ),
-                    giveCharactersRefs,
-                  ),
-                },
-              ),
               updatedCharacters: fql.Foreach(
                 giveCharactersRefs,
                 (characterRef) =>


### PR DESCRIPTION
fixed #135 by using a fauna index to get characters owned by the user. removing the requirement to manually compile and keep an array of characters up-to-date, which caused many strange issues.

> **Warning** changes were already deployed to fauna before PR was merged since I wanted a large older dataset to test on