### PR TITLE
Allow Bot To Publish

### DIFF
--- a/src/community.ts
+++ b/src/community.ts
@@ -152,7 +152,8 @@ async function publish(req: Request): Promise<Response> {
     );
   }
 
-  const { accessToken, manifest } = body as {
+  const { accessToken, tokenType, manifest } = body as {
+    tokenType?: string;
     accessToken: string;
     manifest: Manifest;
   };
@@ -172,7 +173,9 @@ async function publish(req: Request): Promise<Response> {
     method: 'GET',
     headers: {
       'content-type': 'application/json',
-      'authorization': `Bearer ${accessToken}`,
+      'authorization': `${
+        tokenType === 'Bot' ? tokenType : 'Bearer'
+      } ${accessToken}`,
     },
   });
 


### PR DESCRIPTION
- changed endpoint `/community/publish`
  - added body parameter `tokenType` ('Bearer' | 'Bot')
  - body parameter `accessToken` can not be a discord bot token (this is more dangerous, use at your own risk)