### PR TITLE
Remove `bot` scope from invite url

### DIFF
--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -1113,7 +1113,7 @@ if (import.meta.main) {
     '/community/:userId': community.query,
     '/invite': () =>
       Response.redirect(
-        `https://discord.com/api/oauth2/authorize?client_id=${config.appId}&scope=applications.commands%20bot`,
+        `https://discord.com/api/oauth2/authorize?client_id=${config.appId}&scope=applications.commands`,
       ),
     '/external/*': (r) => {
       const { pathname, search } = new URL(r.url);


### PR DESCRIPTION
Due to being unable to verify Fable. Once bot users reach 100 servers they won't be able to join new servers.

This PR remove the `bot` scope from the default invite URL to avoid this happening.