### PR TITLE
Hotfix

### DIFF
--- a/src/community.ts
+++ b/src/community.ts
@@ -49,6 +49,7 @@ async function query(
           author
           image
           url
+          maintainers
           media {
             conflicts
             new {


### PR DESCRIPTION
fix `manifest.maintainers` not returned by `/community/:userid`