### PR TITLE
Hotfix

### DIFF
--- a/src/gacha.ts
+++ b/src/gacha.ts
@@ -325,16 +325,19 @@ async function rngPull(
 }
 
 async function pullAnimation(
-  { token, userId, guildId, quiet, mention, guarantee, pull }: {
+  { token, userId, guildId, quiet, mention, components, guarantee, pull }: {
     token: string;
     pull: Pull;
     userId?: string;
     guildId?: string;
     quiet?: boolean;
     mention?: boolean;
+    components?: boolean;
     guarantee?: number;
   },
 ): Promise<void> {
+  components ??= true;
+
   const characterId = `${pull.character.packId}:${pull.character.id}`;
 
   const mediaIds = [
@@ -400,7 +403,7 @@ async function pullAnimation(
     },
   });
 
-  if (userId) {
+  if (components && userId) {
     if (
       typeof guarantee === 'number' &&
       pull.guarantees?.length &&

--- a/src/synthesis.ts
+++ b/src/synthesis.ts
@@ -309,7 +309,13 @@ function confirmed({
         },
       });
 
-      return gacha.pullAnimation({ token, guildId, pull });
+      return gacha.pullAnimation({
+        token,
+        guildId,
+        userId,
+        pull,
+        components: false,
+      });
     })
     .catch(async (err) => {
       if (err instanceof PoolError) {

--- a/tests/synthesis.test.ts
+++ b/tests/synthesis.test.ts
@@ -430,7 +430,7 @@ Deno.test('synthesis confirmed', async (test) => {
         },
       );
 
-      await timeStub.tickAsync(4000);
+      await timeStub.nextAsync();
 
       assertSpyCalls(fetchStub, 4);
 
@@ -459,7 +459,7 @@ Deno.test('synthesis confirmed', async (test) => {
         },
       );
 
-      await timeStub.tickAsync(6000);
+      await timeStub.nextAsync();
 
       assertSpyCalls(fetchStub, 5);
 
@@ -510,6 +510,315 @@ Deno.test('synthesis confirmed', async (test) => {
       );
 
       await timeStub.runMicrotasks();
+    } finally {
+      delete config.appId;
+      delete config.origin;
+
+      fetchStub.restore();
+      synthesisStub.restore();
+      userStub.restore();
+      gachaStub.restore();
+      timeStub.restore();
+    }
+  });
+
+  await test.step('liked', async () => {
+    const media: AniListMedia = {
+      id: '2',
+      packId: 'anilist',
+      type: MediaType.Anime,
+      format: MediaFormat.TV,
+      popularity: 150_000,
+      title: {
+        english: 'title',
+      },
+      coverImage: {
+        extraLarge: 'media_image_url',
+      },
+    };
+
+    const character: AniListCharacter = {
+      id: '1',
+      packId: 'anilist',
+      name: {
+        full: 'name',
+      },
+      image: {
+        large: 'character_image_url',
+      },
+      media: {
+        edges: [{
+          characterRole: CharacterRole.Supporting,
+          node: media,
+        }],
+      },
+    };
+
+    const timeStub = new FakeTime();
+
+    const fetchStub = stub(
+      globalThis,
+      'fetch',
+      returnsNext([
+        {
+          ok: true,
+          text: (() =>
+            Promise.resolve(JSON.stringify({
+              data: {
+                Page: {
+                  characters: [character],
+                  // media: [media],
+                },
+              },
+            }))),
+        } as any,
+        {
+          ok: true,
+          text: (() =>
+            Promise.resolve(JSON.stringify({
+              data: {
+                replaceCharacters: {
+                  ok: true,
+                },
+              },
+            }))),
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      ] as any),
+    );
+
+    const userStub = stub(
+      user,
+      'getActiveInventories',
+      () =>
+        Promise.resolve([{
+          user: {
+            id: 'another_user_id',
+            likes: [{ characterId: 'anilist:1' }],
+          },
+        } as Schema.Inventory]),
+    );
+
+    const gachaStub = stub(gacha, 'guaranteedPool', () =>
+      Promise.resolve({
+        pool: [{ id: 'anilist:1', mediaId: 'anilist:2', rating: 1 }],
+        validate: () => true,
+      }));
+
+    const synthesisStub = stub(
+      synthesis,
+      'getFilteredCharacters',
+      () =>
+        Promise.resolve([
+          {
+            mediaId: 'media_id',
+            user: { id: 'user_id' },
+            id: 'anilist:1',
+            rating: 1,
+          },
+          {
+            mediaId: 'media_id',
+            user: { id: 'user_id' },
+            id: 'anilist:2',
+            rating: 1,
+          },
+          {
+            mediaId: 'media_id',
+            user: { id: 'user_id' },
+            id: 'anilist:3',
+            rating: 1,
+          },
+          {
+            mediaId: 'media_id',
+            user: { id: 'user_id' },
+            id: 'anilist:4',
+            rating: 1,
+          },
+          {
+            mediaId: 'media_id',
+            user: { id: 'user_id' },
+            id: 'anilist:5',
+            rating: 1,
+          },
+        ]),
+    );
+
+    config.appId = 'app_id';
+    config.origin = 'http://localhost:8000';
+
+    try {
+      const message = synthesis.confirmed({
+        token: 'test_token',
+        userId: 'user_id',
+        guildId: 'guild_id',
+        target: 2,
+      });
+
+      assertEquals(message.json(), {
+        type: 4,
+        data: {
+          attachments: [],
+          components: [],
+          embeds: [{
+            type: 'rich',
+            image: {
+              url: 'http://localhost:8000/assets/spinner.gif',
+            },
+          }],
+        },
+      });
+
+      await timeStub.runMicrotasks();
+
+      assertSpyCalls(fetchStub, 3);
+
+      assertEquals(
+        fetchStub.calls[2].args[0],
+        'https://discord.com/api/v10/webhooks/app_id/test_token/messages/@original',
+      );
+
+      assertEquals(fetchStub.calls[2].args[1]?.method, 'PATCH');
+
+      assertEquals(
+        JSON.parse(
+          (fetchStub.calls[2].args[1]?.body as FormData)?.get(
+            'payload_json',
+          ) as any,
+        ),
+        {
+          embeds: [{
+            type: 'rich',
+            title: 'title',
+            image: {
+              url: 'http://localhost:8000/external/media_image_url?size=medium',
+            },
+          }],
+          components: [],
+          attachments: [],
+        },
+      );
+
+      await timeStub.nextAsync();
+
+      assertSpyCalls(fetchStub, 4);
+
+      assertEquals(
+        fetchStub.calls[3].args[0],
+        'https://discord.com/api/v10/webhooks/app_id/test_token/messages/@original',
+      );
+
+      assertEquals(fetchStub.calls[3].args[1]?.method, 'PATCH');
+
+      assertEquals(
+        JSON.parse(
+          (fetchStub.calls[3].args[1]?.body as FormData)?.get(
+            'payload_json',
+          ) as any,
+        ),
+        {
+          embeds: [{
+            type: 'rich',
+            image: {
+              url: 'http://localhost:8000/assets/stars/2.gif',
+            },
+          }],
+          components: [],
+          attachments: [],
+        },
+      );
+
+      await timeStub.nextAsync();
+
+      assertSpyCalls(fetchStub, 5);
+
+      assertEquals(
+        fetchStub.calls[4].args[0],
+        'https://discord.com/api/v10/webhooks/app_id/test_token/messages/@original',
+      );
+
+      assertEquals(fetchStub.calls[4].args[1]?.method, 'PATCH');
+
+      assertEquals(
+        JSON.parse(
+          (fetchStub.calls[4].args[1]?.body as FormData)?.get(
+            'payload_json',
+          ) as any,
+        ),
+        {
+          attachments: [],
+          embeds: [{
+            type: 'rich',
+            description: new Rating({ stars: 2 }).emotes,
+            fields: [{
+              name: 'title',
+              value: '**name**',
+            }],
+            image: {
+              url: 'http://localhost:8000/external/character_image_url',
+            },
+          }],
+          components: [{
+            type: 1,
+            components: [
+              {
+                custom_id: 'character=anilist:1=1',
+                label: '/character',
+                style: 2,
+                type: 2,
+              },
+              {
+                custom_id: 'like=anilist:1',
+                label: '/like',
+                style: 2,
+                type: 2,
+              },
+            ],
+          }],
+        },
+      );
+
+      await timeStub.runMicrotasks();
+
+      assertSpyCalls(fetchStub, 6);
+
+      assertEquals(
+        fetchStub.calls[5].args[0],
+        'https://discord.com/api/v10/webhooks/app_id/test_token',
+      );
+
+      assertEquals(fetchStub.calls[5].args[1]?.method, 'POST');
+
+      assertEquals(
+        JSON.parse(
+          (fetchStub.calls[5].args[1]?.body as FormData)?.get(
+            'payload_json',
+          ) as any,
+        ),
+        {
+          components: [],
+          attachments: [],
+          content: '<@another_user_id>',
+          embeds: [
+            {
+              type: 'rich',
+              description: '<@user_id>',
+              fields: [
+                {
+                  name: 'title',
+                  value: '**name**',
+                },
+              ],
+              thumbnail: {
+                url:
+                  'http://localhost:8000/external/character_image_url?size=thumbnail',
+              },
+            },
+          ],
+        },
+      );
     } finally {
       delete config.appId;
       delete config.origin;


### PR DESCRIPTION
- owners were pinged incorrectly on `/merge` if character was liked
- the liked character embed didn't show the owner's name

this was the result of synthesis not providing the `userId` to pull animations.