### PR TITLE
fix likeslist empty pages

### DIFF
--- a/src/user.ts
+++ b/src/user.ts
@@ -1437,11 +1437,17 @@ function likeslist({
       });
 
       if (embed.getFieldsCount() <= 0) {
-        message.addEmbed(embed.setDescription(
-          `${nick ? `<@${userId}> doesn't` : 'You don\'t'} have any likes`,
-        ));
+        if (index > 0) {
+          embed.setDescription(
+            'This page is empty',
+          );
+        } else {
+          message.addEmbed(embed.setDescription(
+            `${nick ? `<@${userId}> doesn't` : 'You don\'t'} have any likes`,
+          ));
 
-        return message.patch(token);
+          return message.patch(token);
+        }
       }
 
       return discord.Message.page({

--- a/tests/gacha.test.ts
+++ b/tests/gacha.test.ts
@@ -72,9 +72,8 @@ function fakePool(
           rating: rating ??
             Rating.fromCharacter(node as AniListCharacter).stars,
           id: `${node.packId}:${node.id}`,
-          mediaId: `${
-            (node as AniListCharacter).media?.edges[0]?.node.packId
-          }:${(node as AniListCharacter).media?.edges[0]?.node.id}`,
+          mediaId: `${(node as AniListCharacter).media?.edges[0]?.node
+            .packId}:${(node as AniListCharacter).media?.edges[0]?.node.id}`,
         })),
       },
     });


### PR DESCRIPTION
in some cases, a page in `/likeslist` can be empty which causes a "You don't have any likes" message to be sent incorrectly. That was temporarily fixed by allowing users to navigate empty pages, in the future we should patch that so there are no empty pages in the first place.