### PR TITLE
fix user likes not aggregating in gacha pulls

### DIFF
--- a/db/getInventory.ts
+++ b/db/getInventory.ts
@@ -310,9 +310,18 @@ export async function getInstanceInventories(
     return true;
   });
 
-  const users = await db.getManyValues<Schema.User>(
+  const users = (await db.getManyValues<Schema.User>(
     inventories.map(({ user }) => ['users', user]),
+  )).filter(Boolean) as Schema.User[];
+
+  const likes = await db.getManyBlobValues<Schema.Like[]>(
+    users.map(({ id }) => usersLikesByDiscordId(id)),
   );
+
+  for (let i = 0; i < users.length; i++) {
+    const user = users[i];
+    user.likes = likes[i];
+  }
 
   // deno-lint-ignore no-non-null-assertion
   return inventories.map((inventory, i) => [inventory, users[i]!]);

--- a/db/mod.ts
+++ b/db/mod.ts
@@ -160,13 +160,26 @@ async function getManyValues<T>(
 ): Promise<(T | undefined)[]> {
   const promises = [];
 
-  for (const batch of utils.chunks(keys, 10)) {
+  for (const batch of utils.chunks(keys, 100)) {
     promises.push(kv.getMany<T[]>(batch));
   }
 
   return (await Promise.all(promises))
     .flat()
     .map((entry) => entry?.value ?? undefined);
+}
+
+async function getManyBlobValues<T>(
+  keys: Deno.KvKey[],
+): Promise<(T | undefined)[]> {
+  const promises = [];
+
+  for (const key of keys) {
+    promises.push(getBlobValue<T>(key));
+  }
+
+  return (await Promise.all(promises))
+    .map((entry) => entry ?? undefined);
 }
 
 const db = {
@@ -179,6 +192,7 @@ const db = {
   getManyValues,
   //
   getBlobValue,
+  getManyBlobValues,
   setBlobValue,
   //
   getGuild,


### PR DESCRIPTION
It broke after upgrading user likes (in #296) to its own db document and never updating `db.getInstanceInventories()` to aggregate the new likes document for each user.

This fix slows the already slow `getInstanceInventories` function but the performance of this specific function never mattered, as long as it's under 15 minutes (_discord's timeout on the key used to reply to the original message_). 