### PR TITLE
add `/api/pack/:packId`

### DIFF
--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -1406,6 +1406,7 @@ if (import.meta.main) {
     '/api/user': communityAPI.user,
     '/api/publish': communityAPI.publish,
     '/api/popular': communityAPI.popular,
+    '/api/pack/:packId+': communityAPI.pack,
     '/webhooks/topgg': webhooks.topgg,
     '/external/*': utils.handleProxy,
     '/assets/:filename+': utils.serveStatic('../assets/public', {

--- a/tests/communityAPI.test.ts
+++ b/tests/communityAPI.test.ts
@@ -473,3 +473,425 @@ Deno.test('/publish', async (test) => {
     assertEquals(response.statusText, 'Under Maintenance');
   });
 });
+
+Deno.test('/pack', async (test) => {
+  await test.step('normal', async () => {
+    const getPack = stub(
+      db,
+      'getValue',
+      () =>
+        ({
+          owner: 'user_id',
+          manifest: {
+            private: false,
+          },
+        }) as any,
+    );
+
+    config.communityPacksBrowseAPI = true;
+    config.communityPacksMaintainerAPI = true;
+
+    try {
+      const request = new Request('http://localhost:8000', {
+        method: 'GET',
+      });
+
+      const response = await communityAPI.pack(request, {
+        packId: 'pack-id',
+      });
+
+      assertEquals(getPack.calls[0].args[0], [
+        'packs_by_manifest_id',
+        'pack-id',
+      ]);
+
+      assertEquals(response.ok, true);
+      assertEquals(response.status, 200);
+      assertEquals(response.statusText, 'OK');
+    } finally {
+      delete config.communityPacksBrowseAPI;
+      delete config.communityPacksMaintainerAPI;
+
+      getPack.restore();
+    }
+  });
+
+  await test.step('private pack with authorization as owner', async () => {
+    const fetchStub = stub(
+      utils,
+      'fetchWithRetry',
+      returnsNext([
+        { ok: true, json: (() => Promise.resolve({ id: 'user_id' })) } as any,
+      ]),
+    );
+
+    const getPack = stub(
+      db,
+      'getValue',
+      () =>
+        ({
+          owner: 'user_id',
+          manifest: {
+            private: true,
+          },
+        }) as any,
+    );
+
+    config.communityPacksBrowseAPI = true;
+    config.communityPacksMaintainerAPI = true;
+
+    try {
+      const request = new Request('http://localhost:8000', {
+        method: 'GET',
+        headers: { 'authorization': 'Bearer token' },
+      });
+
+      const response = await communityAPI.pack(request, {
+        packId: 'pack-id',
+      });
+
+      assertSpyCall(fetchStub, 0, {
+        args: ['https://discord.com/api/users/@me', {
+          method: 'GET',
+          headers: {
+            'content-type': 'application/json',
+            'authorization': `Bearer token`,
+          },
+        }],
+      });
+
+      assertEquals(getPack.calls[0].args[0], [
+        'packs_by_manifest_id',
+        'pack-id',
+      ]);
+
+      assertEquals(response.ok, true);
+      assertEquals(response.status, 200);
+      assertEquals(response.statusText, 'OK');
+    } finally {
+      delete config.communityPacksBrowseAPI;
+      delete config.communityPacksMaintainerAPI;
+
+      fetchStub.restore();
+      getPack.restore();
+    }
+  });
+
+  await test.step('private pack with authorization as maintainer', async () => {
+    const fetchStub = stub(
+      utils,
+      'fetchWithRetry',
+      returnsNext([
+        { ok: true, json: (() => Promise.resolve({ id: 'user_id' })) } as any,
+      ]),
+    );
+
+    const getPack = stub(
+      db,
+      'getValue',
+      () =>
+        ({
+          owner: 'another_user_id',
+          manifest: {
+            private: true,
+            maintainers: ['user_id'],
+          },
+        }) as any,
+    );
+
+    config.communityPacksBrowseAPI = true;
+    config.communityPacksMaintainerAPI = true;
+
+    try {
+      const request = new Request('http://localhost:8000', {
+        method: 'GET',
+        headers: { 'authorization': 'Bearer token' },
+      });
+
+      const response = await communityAPI.pack(request, {
+        packId: 'pack-id',
+      });
+
+      assertSpyCall(fetchStub, 0, {
+        args: ['https://discord.com/api/users/@me', {
+          method: 'GET',
+          headers: {
+            'content-type': 'application/json',
+            'authorization': `Bearer token`,
+          },
+        }],
+      });
+
+      assertEquals(getPack.calls[0].args[0], [
+        'packs_by_manifest_id',
+        'pack-id',
+      ]);
+
+      assertEquals(response.ok, true);
+      assertEquals(response.status, 200);
+      assertEquals(response.statusText, 'OK');
+    } finally {
+      delete config.communityPacksBrowseAPI;
+      delete config.communityPacksMaintainerAPI;
+
+      fetchStub.restore();
+      getPack.restore();
+    }
+  });
+
+  await test.step('private pack with wrong authorization', async () => {
+    const fetchStub = stub(
+      utils,
+      'fetchWithRetry',
+      returnsNext([
+        { ok: true, json: (() => Promise.resolve({ id: 'user_id' })) } as any,
+      ]),
+    );
+
+    const getPack = stub(
+      db,
+      'getValue',
+      () =>
+        ({
+          owner: 'another_user_id',
+          manifest: {
+            private: true,
+            maintainers: ['another_user_id_2'],
+          },
+        }) as any,
+    );
+
+    config.communityPacksBrowseAPI = true;
+    config.communityPacksMaintainerAPI = true;
+
+    try {
+      const request = new Request('http://localhost:8000', {
+        method: 'GET',
+        headers: { 'authorization': 'Bearer token' },
+      });
+
+      const response = await communityAPI.pack(request, {
+        packId: 'pack-id',
+      });
+
+      assertSpyCall(fetchStub, 0, {
+        args: ['https://discord.com/api/users/@me', {
+          method: 'GET',
+          headers: {
+            'content-type': 'application/json',
+            'authorization': `Bearer token`,
+          },
+        }],
+      });
+
+      assertEquals(getPack.calls[0].args[0], [
+        'packs_by_manifest_id',
+        'pack-id',
+      ]);
+
+      assertEquals(response.ok, false);
+      assertEquals(response.status, 403);
+      assertEquals(response.statusText, 'Forbidden');
+    } finally {
+      delete config.communityPacksBrowseAPI;
+      delete config.communityPacksMaintainerAPI;
+
+      fetchStub.restore();
+      getPack.restore();
+    }
+  });
+
+  await test.step('private pack without authorization', async () => {
+    const getPack = stub(
+      db,
+      'getValue',
+      () =>
+        ({
+          owner: 'user_id',
+          manifest: {
+            private: true,
+          },
+        }) as any,
+    );
+
+    config.communityPacksBrowseAPI = true;
+    config.communityPacksMaintainerAPI = true;
+
+    try {
+      const request = new Request('http://localhost:8000', {
+        method: 'GET',
+      });
+
+      const response = await communityAPI.pack(request, {
+        packId: 'pack-id',
+      });
+
+      assertEquals(getPack.calls[0].args[0], [
+        'packs_by_manifest_id',
+        'pack-id',
+      ]);
+
+      assertEquals(response.ok, false);
+      assertEquals(response.status, 403);
+      assertEquals(response.statusText, 'Forbidden');
+    } finally {
+      delete config.communityPacksBrowseAPI;
+      delete config.communityPacksMaintainerAPI;
+
+      getPack.restore();
+    }
+  });
+
+  await test.step('not found', async () => {
+    const getPack = stub(
+      db,
+      'getValue',
+      () => undefined as any,
+    );
+
+    config.communityPacksBrowseAPI = true;
+    config.communityPacksMaintainerAPI = true;
+
+    try {
+      const request = new Request('http://localhost:8000', {
+        method: 'GET',
+      });
+
+      const response = await communityAPI.pack(request, {
+        packId: 'pack-id',
+      });
+
+      assertEquals(getPack.calls[0].args[0], [
+        'packs_by_manifest_id',
+        'pack-id',
+      ]);
+
+      assertEquals(response.ok, false);
+      assertEquals(response.status, 404);
+      assertEquals(response.statusText, 'Not Found');
+    } finally {
+      delete config.communityPacksBrowseAPI;
+      delete config.communityPacksMaintainerAPI;
+
+      getPack.restore();
+    }
+  });
+
+  await test.step('invalid access token', async () => {
+    const fetchStub = stub(
+      utils,
+      'fetchWithRetry',
+      returnsNext([
+        {
+          ok: false,
+          status: 403,
+          statusText: 'Unauthorized',
+          json: (() =>
+            Promise.resolve({
+              error: 'invalid access token',
+            })),
+        } as any,
+      ]),
+    );
+
+    config.communityPacksBrowseAPI = true;
+    config.communityPacksMaintainerAPI = true;
+
+    try {
+      const request = new Request('http://localhost:8000', {
+        method: 'GET',
+        headers: { 'authorization': 'Bearer token' },
+      });
+
+      const response = await communityAPI.pack(request, {
+        packId: 'pack-id',
+      });
+
+      assertSpyCalls(fetchStub, 1);
+
+      assertSpyCall(fetchStub, 0, {
+        args: ['https://discord.com/api/users/@me', {
+          method: 'GET',
+          headers: {
+            'content-type': 'application/json',
+            'authorization': `Bearer token`,
+          },
+        }],
+      });
+
+      assertEquals(response.ok, false);
+      assertEquals(response.status, 403);
+      assertEquals(response.statusText, 'Unauthorized');
+
+      assertEquals(await response.json(), {
+        error: 'invalid access token',
+      });
+    } finally {
+      delete config.communityPacksBrowseAPI;
+      delete config.communityPacksMaintainerAPI;
+
+      fetchStub.restore();
+    }
+  });
+
+  await test.step('missing pack id parameter', async () => {
+    config.communityPacksBrowseAPI = true;
+    config.communityPacksMaintainerAPI = true;
+
+    try {
+      const request = new Request('http://localhost:8000', {
+        method: 'GET',
+      });
+
+      const response = await communityAPI.pack(request, {});
+
+      assertEquals(response.ok, false);
+      assertEquals(response.status, 400);
+      assertEquals(response.statusText, 'Bad Request');
+    } finally {
+      delete config.communityPacksBrowseAPI;
+      delete config.communityPacksMaintainerAPI;
+    }
+  });
+
+  await test.step('under maintenance', async () => {
+    config.communityPacksBrowseAPI = false;
+    config.communityPacksMaintainerAPI = true;
+
+    try {
+      const request = new Request('http://localhost:8000', {
+        method: 'GET',
+      });
+
+      const response = await communityAPI.pack(request, {});
+
+      assertEquals(response.ok, false);
+      assertEquals(response.status, 503);
+      assertEquals(response.statusText, 'Under Maintenance');
+    } finally {
+      delete config.communityPacksBrowseAPI;
+      delete config.communityPacksMaintainerAPI;
+    }
+  });
+
+  await test.step('under maintenance 2', async () => {
+    config.communityPacksBrowseAPI = true;
+    config.communityPacksMaintainerAPI = false;
+
+    try {
+      const request = new Request('http://localhost:8000', {
+        method: 'GET',
+        headers: { 'authorization': 'Bearer token' },
+      });
+
+      const response = await communityAPI.pack(request, {});
+
+      assertEquals(response.ok, false);
+      assertEquals(response.status, 503);
+      assertEquals(response.statusText, 'Under Maintenance');
+    } finally {
+      delete config.communityPacksBrowseAPI;
+      delete config.communityPacksMaintainerAPI;
+    }
+  });
+});


### PR DESCRIPTION
Just remembered why I added that this API the last PR, because https://packs.deno.dev will offer direct URLs to packs e.g. https://packs.deno.dev/view/genshin so the app will need to request that pack from Fable.