### PR TITLE
API changes

### DIFF
--- a/db/getPack.ts
+++ b/db/getPack.ts
@@ -8,7 +8,7 @@ export async function getAllPublicPacks(): Promise<Schema.Pack[]> {
   const packs = await db.getValues<Schema.Pack>({ prefix: ['packs'] });
 
   return packs
-    .filter(({ manifest }) => !manifest.private);
+    .filter(({ manifest }) => !manifest.private || !manifest.nsfw);
 }
 
 export async function getPacksByMaintainerId(

--- a/db/getPack.ts
+++ b/db/getPack.ts
@@ -8,7 +8,9 @@ export async function getAllPublicPacks(): Promise<Schema.Pack[]> {
   const packs = await db.getValues<Schema.Pack>({ prefix: ['packs'] });
 
   return packs
-    .filter(({ manifest }) => !manifest.private || !manifest.nsfw);
+    .filter(({ hidden, manifest }) =>
+      !hidden || !manifest.private || !manifest.nsfw
+    );
 }
 
 export async function getPacksByMaintainerId(

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -70,6 +70,7 @@ export interface Pack extends Collection {
   manifest: Manifest;
   servers?: number;
   approved?: boolean;
+  hidden?: boolean;
 }
 
 export interface AcquiredCharacterSkill {

--- a/json/schema.json
+++ b/json/schema.json
@@ -46,6 +46,11 @@
       "description": "A discord webhook url that can be used to publish changes to a server",
       "$comment": "this is a meta parameter, functionality is not handled by fable itself"
     },
+    "nsfw": {
+      "title": "nsfw",
+      "type": "boolean",
+      "description": "Mark the pack as not safe for work, meaning it contains, ranchy, ecchi, or hentai characters"
+    },
     "private": {
       "title": "private",
       "type": "boolean",

--- a/src/communityAPI.ts
+++ b/src/communityAPI.ts
@@ -11,6 +11,7 @@ import { packByManifestId } from '../db/indices.ts';
 import type { Manifest } from './types.ts';
 
 import type * as Schema from '../db/schema.ts';
+import { media } from '../packs/anilist/api.ts';
 
 export async function user(req: Request): Promise<Response> {
   const url = new URL(req.url);
@@ -162,7 +163,10 @@ export async function popular(req: Request): Promise<Response> {
       title: pack.manifest.title,
       description: pack.manifest.description,
       image: pack.manifest.image,
-    },
+      media: pack.manifest.media?.new?.length ?? 0,
+      characters: pack.manifest.characters?.new?.length ?? 0,
+      // deno-lint-ignore no-explicit-any
+    } as any,
   }));
 
   return utils.json(data);

--- a/src/communityAPI.ts
+++ b/src/communityAPI.ts
@@ -11,7 +11,6 @@ import { packByManifestId } from '../db/indices.ts';
 import type { Manifest } from './types.ts';
 
 import type * as Schema from '../db/schema.ts';
-import { media } from '../packs/anilist/api.ts';
 
 export async function user(req: Request): Promise<Response> {
   const url = new URL(req.url);

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,6 +154,7 @@ export interface Manifest {
   author?: string;
   image?: string;
   url?: string;
+  nsfw?: boolean;
   webhookUrl?: string;
   private?: boolean;
   maintainers?: string[];


### PR DESCRIPTION
- return the sum number of media and characters in `/api/popular`

- add a `nsfw` parameter to packs' manifest
_packs with this parameter set to `true` won't show up in `/api/popular`_

- add a `hidden` parameter to packs'
_packs with this parameter set to `true` won't show up in `/api/popular`_
_this one is for our mod team to hide packs by force from the popular list_