### PR TITLE
fix broken random skills

### DIFF
--- a/db/addCharacter.ts
+++ b/db/addCharacter.ts
@@ -2,7 +2,7 @@ import db from '~/db/mod.ts';
 
 import utils from '~/src/utils.ts';
 
-import skills from '~/src/skills.ts';
+import { skills } from '~/src/skills.ts';
 
 import { NoPullsError } from '~/src/errors.ts';
 


### PR DESCRIPTION
The initial skills given to characters when pulled were broken. We have fixed this for all old characters, and this patch will fix it for all new pulls.