### PR TITLE
Switch Images to Attachments

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -34,7 +34,6 @@
     "dax": "https://deno.land/x/dax@0.39.2/mod.ts",
     "ajv": "https://esm.sh/ajv@8.12.0",
     "awesome-ajv": "https://esm.sh/awesome-ajv-errors@5.1.0",
-    "lru": "https://deno.land/x/lru@1.0.2/mod.ts",
     "sentry": "https://raw.githubusercontent.com/timfish/sentry-deno/fb3c482d4e7ad6c4cf4e7ec657be28768f0e729f/mod.ts",
     "tweetnacl": "https://esm.sh/tweetnacl@1.0.3",
     "mongodb": "npm:mongodb",

--- a/deno.json
+++ b/deno.json
@@ -35,7 +35,7 @@
     "ajv": "https://esm.sh/ajv@8.12.0",
     "awesome-ajv": "https://esm.sh/awesome-ajv-errors@5.1.0",
     "lru": "https://deno.land/x/lru@1.0.2/mod.ts",
-    "sentry": "npm:@sentry/node",
+    "sentry": "https://raw.githubusercontent.com/timfish/sentry-deno/fb3c482d4e7ad6c4cf4e7ec657be28768f0e729f/mod.ts",
     "tweetnacl": "https://esm.sh/tweetnacl@1.0.3",
     "mongodb": "npm:mongodb",
     "mongodb-memory-server": "npm:mongodb-memory-server-core",

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1,9 +1,14 @@
+import { basename, extname } from '$std/path/mod.ts';
+
 import { json } from 'sift';
 
 import i18n from '~/src/i18n.ts';
+
 import utils, { ImageSize } from '~/src/utils.ts';
 
 import config from '~/src/config.ts';
+
+import { proxy } from 'images-proxy';
 
 const splitter = '=';
 
@@ -11,6 +16,12 @@ enum CommandType {
   CHAT = 1,
   USER = 2,
 }
+
+type Attachment = {
+  arrayBuffer: ArrayBuffer;
+  filename: string;
+  type: string;
+};
 
 export type AvailableLocales =
   // https://discord.com/developers/docs/reference#locales
@@ -505,11 +516,11 @@ export class Component {
 
 export class Embed {
   #data: EmbedInternal;
+  #files: File[];
 
   constructor(type: 'rich' = 'rich') {
-    this.#data = {
-      type,
-    };
+    this.#files = [];
+    this.#data = { type };
   }
 
   setTitle(title?: string): Embed {
@@ -575,70 +586,78 @@ export class Embed {
     return this.#data.fields?.length ?? 0;
   }
 
-  setImage(image: {
-    url?: string;
-    default?: boolean;
-    proxy?: boolean;
-    size?: ImageSize;
-  }): Embed {
-    const size = image.size === ImageSize.Medium ? '?size=medium' : '';
-
-    image.default = image.default ?? true;
-    image.proxy = image.proxy ?? true;
-
-    if (image.url || image.default) {
-      if (
-        config.disableImagesProxy ||
-        image.url?.startsWith('attachment://') ||
-        (config.origin && image.url?.startsWith(config.origin)) ||
-        !image.proxy
-      ) {
-        this.#data.image = {
-          // deno-lint-ignore no-non-null-assertion
-          url: image.url!,
-        };
-      } else {
-        this.#data.image = {
-          url: `${config.origin}/external/${
-            encodeURIComponent(image.url ?? '')
-          }${size}`,
-        };
-      }
-    }
+  setImageUrl(url: string): Embed {
+    this.#data.image = { url };
     return this;
   }
 
-  setThumbnail(
-    thumbnail: {
-      url?: string;
-      preview?: boolean;
-      default?: boolean;
-      proxy?: boolean;
-    },
-  ): Embed {
-    thumbnail.default = thumbnail.default ?? true;
-    thumbnail.proxy = thumbnail.proxy ?? true;
-
-    if (thumbnail.url || thumbnail.default) {
-      if (
-        config.disableImagesProxy ||
-        thumbnail.url?.startsWith('attachment://') ||
-        (config.origin && thumbnail.url?.startsWith(config.origin)) ||
-        !thumbnail.proxy
-      ) {
-        this.#data.thumbnail = {
-          // deno-lint-ignore no-non-null-assertion
-          url: thumbnail.url!,
-        };
-      } else {
-        this.#data.thumbnail = {
-          url: `${config.origin}/external/${
-            encodeURIComponent(thumbnail.url ?? '')
-          }?size=${thumbnail.preview ? 'preview' : 'thumbnail'}`,
-        };
-      }
-    }
+  setThumbnailUrl(url: string): Embed {
+    this.#data.thumbnail = { url };
     return this;
+  }
+
+  setImageFile(path: string): Attachment {
+    const filename = basename(path);
+
+    const arrayBuffer = Deno.readFileSync(path);
+
+    this.#data.image = { url: `attachment://${filename}` };
+
+    switch (extname(path)) {
+      case '.gif':
+        return { arrayBuffer, filename, type: 'image/gif' };
+      default:
+        throw new Error(`${extname(path)}: unsupported`);
+    }
+  }
+
+  async setImageWithProxy(image: {
+    url?: string;
+    default?: boolean;
+    size?: ImageSize;
+  }): Promise<Attachment | undefined> {
+    image.default = image.default ?? true;
+
+    if (config.disableImagesProxy) {
+      // deno-lint-ignore no-non-null-assertion
+      this.#data.image = { url: image.url! };
+    } else {
+      const filename = image.url ? basename(image.url) : 'default.webp';
+
+      const file = await proxy(image.url ?? '', image.size);
+
+      this.#data.image = { url: `attachment://${filename}` };
+
+      return {
+        filename,
+        arrayBuffer: file.image,
+        type: file.format,
+      };
+    }
+  }
+
+  async setThumbnailWithProxy(image: {
+    url?: string;
+    default?: boolean;
+    size?: ImageSize;
+  }): Promise<Attachment | undefined> {
+    image.default = image.default ?? true;
+
+    if (config.disableImagesProxy) {
+      // deno-lint-ignore no-non-null-assertion
+      this.#data.thumbnail = { url: image.url! };
+    } else {
+      const filename = image.url ? basename(image.url) : 'default.webp';
+      const file = await proxy(image.url ?? '', image.size);
+
+      this.#data.thumbnail = { url: `attachment://${filename}` };
+
+      return {
+        filename,
+        arrayBuffer: file.image,
+        type: file.format,
+      };
+    }
   }
 
   setFooter(footer: { text?: string; icon_url?: string }): Embed {
@@ -690,14 +709,6 @@ export class Message {
     };
   }
 
-  clone(): Message {
-    const cloned = new Message();
-    cloned.#files = [...this.#files];
-    cloned.#data.attachments = [...this.#data.attachments];
-    cloned.#data.embeds = [...this.#data.embeds];
-    return cloned;
-  }
-
   setType(type: MessageType): Message {
     this.#type = type;
     return this;
@@ -729,21 +740,23 @@ export class Message {
     return this;
   }
 
-  addAttachment({ arrayBuffer, filename, type }: {
-    arrayBuffer: ArrayBuffer;
-    filename: string;
-    type: string;
-  }): Message {
-    if (!this.#data.attachments) {
-      this.#data.attachments = [];
+  addAttachment(attachment?: Attachment): Message {
+    if (attachment) {
+      if (!this.#data.attachments) {
+        this.#data.attachments = [];
+      }
+
+      this.#data.attachments.push({
+        filename: attachment.filename,
+        id: `${this.#data.attachments.length}`,
+      });
+
+      this.#files.push(
+        new File([attachment.arrayBuffer], attachment.filename, {
+          type: attachment.type,
+        }),
+      );
     }
-
-    this.#data.attachments.push({
-      filename,
-      id: `${this.#data.attachments.length}`,
-    });
-
-    this.#files.push(new File([arrayBuffer], filename, { type }));
 
     return this;
   }
@@ -995,6 +1008,19 @@ export class Message {
     return json({
       type: MessageType.Pong,
     });
+  }
+
+  static spinner(landscape?: boolean): Message {
+    const embed = new Embed();
+    const loading = new Message();
+
+    const image = embed.setImageFile(
+      landscape ? 'assets/public/spinner3.gif' : 'assets/public/spinner.gif',
+    );
+
+    return loading
+      .addEmbed(embed)
+      .addAttachment(image);
   }
 
   static page(

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -590,8 +590,8 @@ export class Embed {
       if (
         config.disableImagesProxy ||
         image.url?.startsWith('attachment://') ||
-        (config.origin && image.url?.startsWith(config.origin) ||
-          (!image.default && !image.proxy))
+        (config.origin && image.url?.startsWith(config.origin)) ||
+        !image.proxy
       ) {
         this.#data.image = {
           // deno-lint-ignore no-non-null-assertion
@@ -623,8 +623,8 @@ export class Embed {
       if (
         config.disableImagesProxy ||
         thumbnail.url?.startsWith('attachment://') ||
-        (config.origin && thumbnail.url?.startsWith(config.origin) ||
-          (!thumbnail.default && !thumbnail.proxy))
+        (config.origin && thumbnail.url?.startsWith(config.origin)) ||
+        !thumbnail.proxy
       ) {
         this.#data.thumbnail = {
           // deno-lint-ignore no-non-null-assertion

--- a/src/gacha.ts
+++ b/src/gacha.ts
@@ -312,15 +312,17 @@ async function pullAnimation(
 
   const mediaImage = pull.media.images?.[0];
 
+  const embed = new discord.Embed()
+    .setTitle(utils.wrap(mediaTitles[0]));
+
+  const mediaImageAttachment = await embed.setImageWithProxy({
+    size: ImageSize.Medium,
+    url: mediaImage?.url,
+  });
+
   let message = new discord.Message()
-    .addEmbed(
-      new discord.Embed()
-        .setTitle(utils.wrap(mediaTitles[0]))
-        .setImage({
-          size: ImageSize.Medium,
-          url: mediaImage?.url,
-        }),
-    );
+    .addEmbed(embed)
+    .addAttachment(mediaImageAttachment);
 
   if (mention && userId) {
     message
@@ -335,13 +337,15 @@ async function pullAnimation(
 
     await utils.sleep(4);
 
+    const embed = new discord.Embed();
+
+    const image = embed.setImageFile(
+      `assets/public/stars/${pull.rating.stars}.gif`,
+    );
+
     message = new discord.Message()
-      .addEmbed(
-        new discord.Embed()
-          .setImage({
-            url: `${config.origin}/assets/stars/${pull.rating.stars}.gif`,
-          }),
-      );
+      .addEmbed(embed)
+      .addAttachment(image);
 
     if (mention && userId) {
       message
@@ -355,7 +359,7 @@ async function pullAnimation(
   }
   //
 
-  message = search.characterMessage(pull.character, {
+  message = await search.characterMessage(pull.character, {
     relations: false,
     rating: pull.rating,
     description: false,
@@ -415,7 +419,7 @@ async function pullAnimation(
     });
 
     if (pings.size > 0) {
-      const embed = search.characterEmbed(pull.character, {
+      const embed = await search.characterEmbed(message, pull.character, {
         userId,
         mode: 'thumbnail',
         rating: true,
@@ -461,14 +465,7 @@ function start(
 
   gacha.rngPull({ userId, guildId, guarantee })
     .then((pull) => {
-      return pullAnimation({
-        token,
-        userId,
-        guildId,
-        mention,
-        quiet,
-        pull,
-      });
+      return pullAnimation({ token, userId, guildId, mention, quiet, pull });
     })
     .catch(async (err) => {
       if (err instanceof NoPullsError) {
@@ -530,20 +527,15 @@ function start(
       await discord.Message.internal(refId).patch(token);
     });
 
-  const spinner = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner.gif` },
-      ),
-    );
+  const loading = discord.Message.spinner();
 
   if (mention) {
-    spinner
+    loading
       .setContent(`<@${userId}>`)
       .setPing();
   }
 
-  return spinner;
+  return loading;
 }
 
 const gacha = {

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -644,25 +644,25 @@ export const handler = async (r: Request) => {
           case 'merge': {
             const target = options['target'] as number;
 
-            return (await merge.synthesize({
+            return merge.synthesize({
               token,
               guildId,
               userId: member.user.id,
               mode: 'target',
               target,
-            })).send();
+            }).send();
           }
           case 'automerge': {
             // deno-lint-ignore no-non-null-assertion
             switch (subcommand!) {
               case 'min':
               case 'max':
-                return (await merge.synthesize({
+                return merge.synthesize({
                   token,
                   guildId,
                   userId: member.user.id,
                   mode: subcommand,
-                })).send();
+                }).send();
               default:
                 break;
             }
@@ -1219,13 +1219,8 @@ export const handler = async (r: Request) => {
             if (userId === member.user.id) {
               battle.skipBattle(id);
 
-              return new discord.Message()
+              return discord.Message.spinner(true)
                 .setType(discord.MessageType.Update)
-                .addEmbed(
-                  new discord.Embed().setImage(
-                    { url: `${config.origin}/assets/spinner3.gif` },
-                  ),
-                )
                 .send();
             }
 
@@ -1406,10 +1401,6 @@ export async function start(): Promise<void> {
     '/api/publish': communityAPI.publish,
     '/api/popular': communityAPI.popular,
     '/api/pack/:packId+': communityAPI.pack,
-    '/external/*': utils.handleProxy,
-    '/assets/:filename+': utils.serveStatic('../assets/public', {
-      baseUrl: import.meta.url,
-    }),
     '/invite': () =>
       Response.redirect(
         `https://discord.com/api/oauth2/authorize?client_id=${config.appId}&scope=applications.commands%20bot`,

--- a/src/packs.ts
+++ b/src/packs.ts
@@ -124,12 +124,11 @@ function packEmbed(pack: Pack): discord.Embed {
   const embed = new discord.Embed()
     .setFooter({ text: pack.manifest.author })
     .setDescription(pack.manifest.description)
-    .setThumbnail({
-      url: pack.manifest.image,
-      default: false,
-      proxy: false,
-    })
     .setTitle(pack.manifest.title ?? pack.manifest.id);
+
+  if (pack.manifest.image) {
+    embed.setThumbnailUrl(pack.manifest.image);
+  }
 
   return embed;
 }

--- a/src/party.ts
+++ b/src/party.ts
@@ -54,7 +54,7 @@ async function embed({ guildId, party, locale }: {
     packs.characters({ ids: ids.filter(utils.nonNullable), guildId }),
   ]);
 
-  ids.forEach((characterId, i) => {
+  await Promise.all(ids.map(async (characterId, i) => {
     if (!characterId) {
       message.addEmbed(new discord.Embed()
         .setDescription(i18n.get('unassigned', locale)));
@@ -84,7 +84,7 @@ async function embed({ guildId, party, locale }: {
       );
     }
 
-    const embed = srch.characterEmbed(character, {
+    const embed = await srch.characterEmbed(message, character, {
       mode: 'thumbnail',
       media: { title: packs.aliasToArray(media[mediaIndex].title)[0] },
       rating: new Rating({ stars: members[i]?.rating }),
@@ -101,7 +101,7 @@ async function embed({ guildId, party, locale }: {
     });
 
     message.addEmbed(embed);
-  });
+  }));
 
   return message;
 }
@@ -132,14 +132,7 @@ function view({ token, userId, guildId }: {
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner3.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner(true);
 }
 
 function assign({
@@ -190,19 +183,21 @@ function assign({
           spot,
         );
 
+        const embed = await srch.characterEmbed(message, results[0], {
+          mode: 'thumbnail',
+          rating: new Rating({ stars: response.rating }),
+          description: true,
+          footer: false,
+          existing: {
+            image: response.image,
+            nickname: response.nickname,
+          },
+        });
+
         return message
           .addEmbed(new discord.Embed()
             .setDescription(i18n.get('assigned', locale)))
-          .addEmbed(srch.characterEmbed(results[0], {
-            mode: 'thumbnail',
-            rating: new Rating({ stars: response.rating }),
-            description: true,
-            footer: false,
-            existing: {
-              image: response.image,
-              nickname: response.nickname,
-            },
-          }))
+          .addEmbed(embed)
           .addComponents([
             new discord.Component()
               .setLabel('/character')
@@ -244,14 +239,7 @@ function assign({
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner3.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner(true);
 }
 
 function swap({ token, a, b, userId, guildId }: {
@@ -288,14 +276,7 @@ function swap({ token, a, b, userId, guildId }: {
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner3.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner(true);
 }
 
 function remove({ token, spot, userId, guildId }: {
@@ -343,18 +324,20 @@ function remove({ token, spot, userId, guildId }: {
           ).patch(token);
       }
 
+      const embed = await srch.characterEmbed(message, characters[0], {
+        mode: 'thumbnail',
+        rating: new Rating({ stars: character.rating }),
+        description: true,
+        footer: false,
+        existing: {
+          image: character.image,
+          nickname: character.nickname,
+        },
+      });
+
       return message
         .addEmbed(new discord.Embed().setDescription('Removed'))
-        .addEmbed(srch.characterEmbed(characters[0], {
-          mode: 'thumbnail',
-          rating: new Rating({ stars: character.rating }),
-          description: true,
-          footer: false,
-          existing: {
-            image: character.image,
-            nickname: character.nickname,
-          },
-        }))
+        .addEmbed(embed)
         .addComponents([
           new discord.Component()
             .setLabel('/character')
@@ -371,14 +354,7 @@ function remove({ token, spot, userId, guildId }: {
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner3.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner(true);
 }
 
 const party = {

--- a/src/search.ts
+++ b/src/search.ts
@@ -32,6 +32,24 @@ const musicUrlRegex = /youtube|spotify/;
 const externalUrlRegex =
   /^(https:\/\/)?(www\.)?(youtube\.com|twitch\.tv|netflix\\.com|crunchyroll\.com|tapas\.io|webtoons\.com|amazon\.com)[\S]*$/;
 
+type CharacterEmbed = {
+  userId?: string;
+  existing?: {
+    image?: string;
+    nickname?: string;
+    rating?: number;
+    mediaId?: string;
+  };
+  suffix?: string;
+  rating?: Rating | boolean;
+  media?: {
+    title?: boolean | string;
+  };
+  mode?: 'thumbnail' | 'full';
+  description?: boolean;
+  footer?: boolean;
+};
+
 function media(
   { token, id, search, debug, guildId }: {
     token: string;
@@ -61,12 +79,12 @@ function media(
     })
     .then(async (media) => {
       if (debug) {
-        return await mediaDebugMessage(media)
-          .patch(token);
+        const message = await mediaDebugMessage(media);
+        return await message.patch(token);
       }
 
-      return await mediaMessage(media)
-        .patch(token);
+      const message = await mediaMessage(media);
+      return await message.patch(token);
     })
     .catch(async (err) => {
       if (err.message === '404') {
@@ -87,17 +105,10 @@ function media(
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner();
 }
 
-function mediaMessage(media: Media): discord.Message {
+async function mediaMessage(media: Media): Promise<discord.Message> {
   const titles = packs.aliasToArray(media.title);
 
   if (!titles?.length) {
@@ -107,21 +118,26 @@ function mediaMessage(media: Media): discord.Message {
   const linksGroup: discord.Component[] = [];
   const musicGroup: discord.Component[] = [];
 
-  const message = new discord.Message()
-    .addEmbed(mediaEmbed(media));
+  const message = new discord.Message();
+
+  const embed = await mediaEmbed(message, media);
+
+  message.addEmbed(embed);
 
   // character embeds
   // sort characters by popularity
-  media.characters?.edges
-    ?.slice(0, 2)
-    .forEach((edge) => {
-      const embed = characterEmbed(edge.node, {
-        mode: 'thumbnail',
-        rating: false,
-      });
+  await Promise.all(
+    media.characters?.edges
+      ?.slice(0, 2)
+      .map(async (edge) => {
+        const embed = await characterEmbed(message, edge.node, {
+          mode: 'thumbnail',
+          rating: false,
+        });
 
-      message.addEmbed(embed);
-    });
+        message.addEmbed(embed);
+      }) ?? [],
+  );
 
   if (media.trailer?.site === 'youtube') {
     const component = new discord.Component()
@@ -192,17 +208,20 @@ function mediaMessage(media: Media): discord.Message {
   return message.addComponents([...linksGroup, ...musicGroup]);
 }
 
-function mediaEmbed(
+async function mediaEmbed(
+  message: discord.Message,
   media: Media | DisaggregatedMedia,
   options?: {
     mode?: 'thumbnail' | 'full';
   },
-): discord.Embed {
+): Promise<discord.Embed> {
   options ??= {
     mode: 'full',
   };
 
   const title = packs.aliasToArray(media.title)[0];
+
+  const image = media.images?.[0]?.url;
 
   const wrapWidth = ['preview', 'thumbnail'].includes(options.mode ?? '')
     ? 25
@@ -213,9 +232,11 @@ function mediaEmbed(
   const embed = new discord.Embed();
 
   if (options.mode === 'full') {
-    embed.setImage({ url: media.images?.[0]?.url });
+    const attachment = await embed.setImageWithProxy({ url: image });
+    message.addAttachment(attachment);
   } else {
-    embed.setThumbnail({ url: media.images?.[0]?.url });
+    const attachment = await embed.setThumbnailWithProxy({ url: image });
+    message.addAttachment(attachment);
   }
 
   const description = options.mode === 'thumbnail'
@@ -229,19 +250,20 @@ function mediaEmbed(
     .setDescription(description);
 }
 
-function mediaDebugMessage(
+async function mediaDebugMessage(
   media: Media | DisaggregatedMedia,
-): discord.Message | discord.Message {
+): Promise<discord.Message> {
   const titles = packs.aliasToArray(media.title);
 
   if (!titles?.length) {
     throw new Error('404');
   }
 
+  const message = new discord.Message();
+
   const embed = new discord.Embed()
     .setTitle(titles.shift())
     .setDescription(titles.join('\n'))
-    .setThumbnail({ url: media.images?.[0]?.url })
     .addField({ name: 'Id', value: `${media.packId}:${media.id}` })
     .addField({
       name: 'Type',
@@ -259,7 +281,13 @@ function mediaDebugMessage(
       inline: true,
     });
 
-  return new discord.Message().addEmbed(embed);
+  const image = await embed.setThumbnailWithProxy({
+    url: media.images?.[0]?.url,
+  });
+
+  return message
+    .addEmbed(embed)
+    .addAttachment(image);
 }
 
 function character(
@@ -309,11 +337,11 @@ function character(
       }
 
       if (debug) {
-        return await characterDebugMessage(character)
-          .patch(token);
+        const message = await characterDebugMessage(character);
+        return await message.patch(token);
       }
 
-      const message = characterMessage(character, {
+      const message = await characterMessage(character, {
         existing: existing ?? undefined,
         userId: existing?.userId,
       });
@@ -353,33 +381,24 @@ function character(
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner();
 }
 
-function characterMessage(
+async function characterMessage(
   character: Character | DisaggregatedCharacter,
-  options?: Parameters<typeof characterEmbed>[1] & {
+  options?: CharacterEmbed & {
     externalLinks?: boolean;
     relations?: boolean | DisaggregatedMedia[];
   },
-): discord.Message {
-  options = {
-    ...{
-      externalLinks: true,
-      relations: true,
-    },
-    ...options,
+): Promise<discord.Message> {
+  options ??= {
+    externalLinks: true,
+    relations: true,
   };
 
-  const message = new discord.Message()
-    .addEmbed(characterEmbed(character, options));
+  const message = new discord.Message();
+
+  message.addEmbed(await characterEmbed(message, character, options));
 
   const group: discord.Component[] = [];
 
@@ -423,7 +442,8 @@ function characterMessage(
   return message.addComponents(group);
 }
 
-function characterEmbed(
+async function characterEmbed(
+  message: discord.Message,
   character: Character | DisaggregatedCharacter,
   options?: {
     userId?: string;
@@ -442,7 +462,7 @@ function characterEmbed(
     description?: boolean;
     footer?: boolean;
   },
-): discord.Embed {
+): Promise<discord.Embed> {
   options = {
     ...{
       mode: 'full',
@@ -469,9 +489,11 @@ function characterEmbed(
   const aliasWrapped = utils.wrap(alias, wrapWidth);
 
   if (options.mode === 'full') {
-    embed.setImage({ url: image?.url });
+    const attachment = await embed.setImageWithProxy({ url: image?.url });
+    message.addAttachment(attachment);
   } else {
-    embed.setThumbnail({ url: image?.url });
+    const attachment = await embed.setThumbnailWithProxy({ url: image?.url });
+    message.addAttachment(attachment);
   }
 
   if (options?.existing?.rating) {
@@ -549,7 +571,9 @@ function characterEmbed(
   return embed;
 }
 
-function characterDebugMessage(character: Character): discord.Message {
+async function characterDebugMessage(
+  character: Character,
+): Promise<discord.Message> {
   const media = character.media?.edges?.[0];
 
   const role = media?.role;
@@ -562,10 +586,11 @@ function characterDebugMessage(character: Character): discord.Message {
 
   const titles = packs.aliasToArray(character.name);
 
+  const message = new discord.Message();
+
   const embed = new discord.Embed()
     .setTitle(titles.splice(0, 1)[0])
     .setDescription(titles.join('\n'))
-    .setThumbnail({ url: character.images?.[0]?.url })
     .addField({ name: 'Id', value: `${character.packId}:${character.id}` })
     .addField({
       name: 'Rating',
@@ -593,6 +618,10 @@ function characterDebugMessage(character: Character): discord.Message {
       inline: true,
     });
 
+  const image = await embed.setThumbnailWithProxy({
+    url: character.images?.[0]?.url,
+  });
+
   if (!media) {
     embed.addField({
       name: '**WARN**',
@@ -601,7 +630,7 @@ function characterDebugMessage(character: Character): discord.Message {
     });
   }
 
-  return new discord.Message().addEmbed(embed);
+  return message.addEmbed(embed).addAttachment(image);
 }
 
 function mediaCharacters(
@@ -654,7 +683,7 @@ function mediaCharacters(
       //   db.findCharacter(guildId, `${character.packId}:${character.id}`),
       // ]);
 
-      const message = characterMessage(character, {
+      const message = await characterMessage(character, {
         rating: new Rating({ role, popularity: media.popularity }),
         relations: false,
         description: true,
@@ -662,7 +691,9 @@ function mediaCharacters(
         footer: true,
         existing: existing ?? undefined,
         userId: existing?.userId,
-      }).addComponents([
+      });
+
+      message.addComponents([
         new discord.Component()
           .setId('media', `${media.packId}:${media.id}`)
           .setLabel(`/${media.type.toLowerCase()}`),
@@ -709,14 +740,7 @@ function mediaCharacters(
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner();
 }
 
 function mediaFound(
@@ -863,14 +887,7 @@ function mediaFound(
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner();
 }
 
 const search = {

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -334,7 +334,7 @@ function preAcquire(
       if (!existing) {
         const message = new discord.Message();
 
-        const embed = search.characterEmbed(character, {
+        const embed = await search.characterEmbed(message, character, {
           mode: 'thumbnail',
           media: { title: false },
           description: false,
@@ -353,7 +353,7 @@ function preAcquire(
       if (existing.userId !== userId) {
         const message = new discord.Message();
 
-        const embed = search.characterEmbed(character, {
+        const embed = await search.characterEmbed(message, character, {
           mode: 'thumbnail',
           media: { title: false },
           description: false,
@@ -380,7 +380,7 @@ function preAcquire(
 
       const charId = `${character.packId}:${character.id}`;
 
-      const embed = search.characterEmbed(character, {
+      const embed = await search.characterEmbed(message, character, {
         mode: 'thumbnail',
         media: { title: false },
         description: false,
@@ -470,14 +470,7 @@ function preAcquire(
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner3.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner(true);
 }
 
 async function acquire(

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -53,7 +53,7 @@ function view({ token, character, userId, guildId }: {
       if (!existing) {
         const message = new discord.Message();
 
-        const embed = search.characterEmbed(character, {
+        const embed = await search.characterEmbed(message, character, {
           mode: 'thumbnail',
           media: { title: false },
           description: false,
@@ -87,7 +87,7 @@ function view({ token, character, userId, guildId }: {
 
       const _skills = Object.entries(existing.combat?.skills ?? {});
 
-      const embed = search.characterEmbed(character, {
+      const embed = await search.characterEmbed(message, character, {
         footer: false,
         existing: {
           image: existing.image,
@@ -179,14 +179,7 @@ function view({ token, character, userId, guildId }: {
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner3.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner(true);
 }
 
 const stats = { view };

--- a/src/tower.ts
+++ b/src/tower.ts
@@ -315,14 +315,7 @@ function view({ token, guildId, userId }: {
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner3.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner(true);
 }
 
 function reclear({ token, guildId, userId }: {
@@ -475,14 +468,7 @@ function reclear({ token, guildId, userId }: {
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner3.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner(true);
 }
 
 async function onFail(

--- a/src/user.ts
+++ b/src/user.ts
@@ -257,6 +257,23 @@ function nick({
 
         const name = packs.aliasToArray(character.name)[0];
 
+        const embed = await srch.characterEmbed(
+          message,
+          character,
+          {
+            footer: true,
+            rating: false,
+            mode: 'thumbnail',
+            description: false,
+            media: { title: true },
+            existing: {
+              ...response,
+              rating: undefined,
+              nickname: nick,
+            },
+          },
+        );
+
         message
           .addEmbed(
             new discord.Embed().setDescription(
@@ -268,21 +285,7 @@ function nick({
               ),
             ),
           )
-          .addEmbed(srch.characterEmbed(
-            character,
-            {
-              footer: true,
-              rating: false,
-              mode: 'thumbnail',
-              description: false,
-              media: { title: true },
-              existing: {
-                ...response,
-                rating: undefined,
-                nickname: nick,
-              },
-            },
-          ));
+          .addEmbed(embed);
 
         return message.patch(token);
       } catch (err) {
@@ -342,14 +345,7 @@ function nick({
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner();
 }
 
 function image({
@@ -403,6 +399,22 @@ function image({
 
         const name = packs.aliasToArray(character.name)[0];
 
+        const embed = await srch.characterEmbed(
+          message,
+          character,
+          {
+            footer: true,
+            rating: false,
+            description: false,
+            media: { title: true },
+            existing: {
+              ...response,
+              rating: undefined,
+              image,
+            },
+          },
+        );
+
         message
           .addEmbed(
             new discord.Embed().setDescription(
@@ -415,20 +427,7 @@ function image({
               ),
             ),
           )
-          .addEmbed(srch.characterEmbed(
-            character,
-            {
-              footer: true,
-              rating: false,
-              description: false,
-              media: { title: true },
-              existing: {
-                ...response,
-                rating: undefined,
-                image,
-              },
-            },
-          ));
+          .addEmbed(embed);
 
         return message.patch(token);
       } catch (err) {
@@ -488,14 +487,7 @@ function image({
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner();
 }
 
 function like({
@@ -563,17 +555,19 @@ function like({
             .setPing();
         }
 
-        message
-          .addEmbed(srch.characterEmbed(
-            character,
-            {
-              footer: true,
-              description: false,
-              mode: 'thumbnail',
-              media: { title: true },
-              rating: true,
-            },
-          ));
+        const embed = await srch.characterEmbed(
+          message,
+          character,
+          {
+            footer: true,
+            description: false,
+            mode: 'thumbnail',
+            media: { title: true },
+            rating: true,
+          },
+        );
+
+        message.addEmbed(embed);
 
         if (!undo) {
           message.addComponents([
@@ -607,14 +601,7 @@ function like({
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner();
 }
 
 function likeall({
@@ -667,8 +654,11 @@ function likeall({
           media: results[0],
         });
 
-        message
-          .addEmbed(srch.mediaEmbed(media, { mode: 'thumbnail' }));
+        const embed = await srch.mediaEmbed(message, media, {
+          mode: 'thumbnail',
+        });
+
+        message.addEmbed(embed);
 
         if (!undo) {
           message.addComponents([
@@ -702,14 +692,7 @@ function likeall({
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner();
 }
 
 function list({
@@ -927,14 +910,7 @@ function list({
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner();
 }
 
 function likeslist({
@@ -1105,14 +1081,7 @@ function likeslist({
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner();
 }
 
 function sum({
@@ -1211,14 +1180,7 @@ function sum({
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner3.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner(true);
 }
 
 function showcase({
@@ -1426,14 +1388,7 @@ function showcase({
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner3.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner(true);
 }
 
 function logs({
@@ -1511,14 +1466,7 @@ function logs({
       await discord.Message.internal(refId).patch(token);
     });
 
-  const loading = new discord.Message()
-    .addEmbed(
-      new discord.Embed().setImage(
-        { url: `${config.origin}/assets/spinner.gif` },
-      ),
-    );
-
-  return loading;
+  return discord.Message.spinner();
 }
 
 const user = {


### PR DESCRIPTION
Due to a bug in discord media proxy (https://github.com/discord/discord-api-docs/issues/6694#issuecomment-2064926272), images are failing to load frequently, a workaround this is using attachments to upload the images, attachments aren't subject to discord media proxy.  


This unfortunately has the downside of increased latency when replying to users commands, since we have to wait for all the images to be uploaded before the message is sent. 