### PR TITLE
fix(gacha): all media should have the same odds

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -37,10 +37,10 @@
     "sentry": "https://raw.githubusercontent.com/timfish/sentry-deno/fb3c482d4e7ad6c4cf4e7ec657be28768f0e729f/mod.ts",
     "tweetnacl": "https://esm.sh/tweetnacl@1.0.3",
     "mongodb": "npm:mongodb",
-    "mongodb-memory-server": "npm:mongodb-memory-server-core@9",
+    "mongodb-memory-server": "npm:mongodb-memory-server-core@9.2.0",
     "levenshtein": "https://deno.land/x/fastest_levenshtein@1.0.10/mod.ts",
     "sift": "https://raw.githubusercontent.com/ker0olos/sift/89e31b5a08af007d51073af31050fc2205245dd3/mod.ts",
-    "search-index": "npm:@fable-community/search-index@0.2.4",
+    "search-index": "npm:@fable-community/search-index@0.2.5",
     "images-proxy": "npm:@fable-community/images-proxy@0.1.5",
     "dyn-images": "npm:@fable-community/dyn-images@0.1.2"
   }

--- a/search-index/mod.ts
+++ b/search-index/mod.ts
@@ -121,7 +121,7 @@ const pool = async (
     role?: CharacterRole;
   },
   guildId: string,
-): Promise<IndexedCharacter[]> => {
+): Promise<Map<string, IndexedCharacter[]>> => {
   const list = await packs.all({ guildId });
 
   const builtin = list[0]?.manifest.id === 'anilist';
@@ -172,17 +172,6 @@ const pool = async (
     filter.popularity?.between?.[1],
     filter.rating,
   );
-
-  // // attempt to speed pulls by pre-removing existing characters on smaller pools
-  // // avoids checking if db.addCharacter() will fail with no-unique error
-  // if (
-  //   (filter.popularity && filter.popularity.between[0] > 200_000) ||
-  //   filter.rating && filter.rating > 3
-  // ) {
-  //   const existing = await db.getGuildCharacters(guildId);
-
-  //   pool = pool.filter(({ id }) => !existing.includes(id));
-  // }
 
   return pool;
 };

--- a/src/steal.ts
+++ b/src/steal.ts
@@ -164,8 +164,6 @@ function pre({ token, userId, guildId, search, id }: {
         targetInventory.party.member5Id,
       ];
 
-      console.log(party, existing._id);
-
       const inactiveDays = getInactiveDays(targetInventory);
 
       if (party.some((id) => id?.equals(existing._id))) {

--- a/src/tower.ts
+++ b/src/tower.ts
@@ -167,6 +167,8 @@ export async function getEnemyCharacter(
     guarantee: getEnemyRating(floor),
   });
 
+  const poolKeys = Array.from(pool.keys());
+
   let character: Character | undefined = undefined;
 
   const controller = new AbortController();
@@ -175,16 +177,23 @@ export async function getEnemyCharacter(
 
   const timeoutId = setTimeout(() => controller.abort(), 1 * 60 * 1000);
 
-  if (!pool.length) {
+  if (!poolKeys.length) {
     throw new PoolError();
   }
 
   try {
     while (!signal.aborted) {
-      const i = Math.floor(random.nextFloat() * pool.length);
+      const mediaIndex = Math.floor(random.nextFloat() * poolKeys.length);
 
-      const characterId = pool[i].id;
+      const mediaCharacters = pool.get(poolKeys[mediaIndex]);
 
+      if (!mediaCharacters) {
+        continue;
+      }
+
+      const i = Math.floor(random.nextFloat() * mediaCharacters.length);
+
+      const characterId = mediaCharacters[i].id;
       const results = await packs.aggregatedCharacters({
         guildId,
         ids: [characterId],

--- a/tests/gacha.test.ts
+++ b/tests/gacha.test.ts
@@ -45,17 +45,19 @@ Deno.test('adding character to inventory', async (test) => {
       searchIndex,
       'pool',
       () =>
-        Promise.resolve([
-          new IndexedCharacter(
-            'anilist:1',
-            '',
-            [],
-            [],
-            2000,
-            1,
-            CharacterRole.Main,
-          ),
-        ]),
+        Promise.resolve(
+          new Map([['', [
+            new IndexedCharacter(
+              'anilist:1',
+              '',
+              [],
+              [],
+              2000,
+              1,
+              CharacterRole.Main,
+            ),
+          ]]]),
+        ),
     );
 
     const rngStub = stub(
@@ -181,17 +183,19 @@ Deno.test('adding character to inventory', async (test) => {
       searchIndex,
       'pool',
       () =>
-        Promise.resolve([
-          new IndexedCharacter(
-            'anilist:1',
-            '',
-            [],
-            [],
-            2000,
-            1,
-            CharacterRole.Main,
-          ),
-        ]),
+        Promise.resolve(
+          new Map([['', [
+            new IndexedCharacter(
+              'anilist:1',
+              '',
+              [],
+              [],
+              2000,
+              1,
+              CharacterRole.Main,
+            ),
+          ]]]),
+        ),
     );
 
     const rngStub = stub(
@@ -296,17 +300,19 @@ Deno.test('adding character to inventory', async (test) => {
       searchIndex,
       'pool',
       () =>
-        Promise.resolve([
-          new IndexedCharacter(
-            'anilist:1',
-            '',
-            [],
-            [],
-            2000,
-            1,
-            CharacterRole.Main,
-          ),
-        ]),
+        Promise.resolve(
+          new Map([['', [
+            new IndexedCharacter(
+              'anilist:1',
+              '',
+              [],
+              [],
+              2000,
+              1,
+              CharacterRole.Main,
+            ),
+          ]]]),
+        ),
     );
 
     const rngStub = stub(
@@ -411,17 +417,19 @@ Deno.test('adding character to inventory', async (test) => {
       searchIndex,
       'pool',
       () =>
-        Promise.resolve([
-          new IndexedCharacter(
-            'anilist:1',
-            '',
-            [],
-            [],
-            2000,
-            1,
-            CharacterRole.Main,
-          ),
-        ]),
+        Promise.resolve(
+          new Map([['', [
+            new IndexedCharacter(
+              'anilist:1',
+              '',
+              [],
+              [],
+              2000,
+              1,
+              CharacterRole.Main,
+            ),
+          ]]]),
+        ),
     );
 
     const rngStub = stub(
@@ -980,7 +988,7 @@ Deno.test('/gacha', async (test) => {
       // deno-lint-ignore require-await
       async () =>
         Promise.resolve({
-          pool: [],
+          pool: new Map(),
           validate: () => false,
         }),
     );
@@ -995,7 +1003,7 @@ Deno.test('/gacha', async (test) => {
       gacha,
       'rangeFallbackPool',
       // deno-lint-ignore require-await
-      async () => Promise.resolve([character]) as any,
+      async () => Promise.resolve(new Map([['', [character]]])) as any,
     );
 
     const addCharacterStub = stub(
@@ -2523,7 +2531,7 @@ Deno.test('/gacha', async (test) => {
       // deno-lint-ignore require-await
       async () =>
         Promise.resolve({
-          pool: [],
+          pool: new Map(),
           validate: () => false,
         }),
     );
@@ -2532,7 +2540,7 @@ Deno.test('/gacha', async (test) => {
       gacha,
       'rangeFallbackPool',
       // deno-lint-ignore require-await
-      async () => Promise.resolve([]),
+      async () => Promise.resolve(new Map()),
     );
 
     config.gacha = true;
@@ -2612,7 +2620,7 @@ Deno.test('/gacha', async (test) => {
       // deno-lint-ignore require-await
       async () =>
         Promise.resolve({
-          pool: [],
+          pool: new Map(),
           validate: () => false,
         }),
     );

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -613,17 +613,19 @@ Deno.test('synthesis confirmed', async (test) => {
       searchIndex,
       'pool',
       () =>
-        Promise.resolve([
-          new IndexedCharacter(
-            'anilist:1',
-            '',
-            [],
-            [],
-            0,
-            2,
-            CharacterRole.Main,
-          ),
-        ]),
+        Promise.resolve(
+          new Map([['', [
+            new IndexedCharacter(
+              'anilist:1',
+              '',
+              [],
+              [],
+              0,
+              2,
+              CharacterRole.Main,
+            ),
+          ]]]),
+        ),
     );
 
     const synthesisStub = stub(
@@ -865,17 +867,19 @@ Deno.test('synthesis confirmed', async (test) => {
       searchIndex,
       'pool',
       () =>
-        Promise.resolve([
-          new IndexedCharacter(
-            'anilist:1',
-            '',
-            [],
-            [],
-            0,
-            2,
-            CharacterRole.Main,
-          ),
-        ]),
+        Promise.resolve(
+          new Map([['', [
+            new IndexedCharacter(
+              'anilist:1',
+              '',
+              [],
+              [],
+              0,
+              2,
+              CharacterRole.Main,
+            ),
+          ]]]),
+        ),
     );
 
     const synthesisStub = stub(


### PR DESCRIPTION
When `search-index` was added and made to handle gacha, it incidentally broke the way the pool was previously setup, it was reverted to favor the media with more characters.

This PR fixes this issue by RNG selecting a media first then a character from it. 